### PR TITLE
Regex String Generator optimisation

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/AtomicConstraintConstructTuple.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/AtomicConstraintConstructTuple.java
@@ -1,0 +1,33 @@
+package com.scottlogic.deg.generator.fieldspecs;
+
+import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
+
+import java.util.Objects;
+
+public class AtomicConstraintConstructTuple {
+    private final AtomicConstraint atomicConstraint;
+    private final boolean matchFullString;
+    private final boolean negate;
+
+    AtomicConstraintConstructTuple(AtomicConstraint atomicConstraint, boolean matchFullString, boolean negate) {
+        this.atomicConstraint = atomicConstraint;
+        this.matchFullString = matchFullString;
+        this.negate = negate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AtomicConstraintConstructTuple that = (AtomicConstraintConstructTuple) o;
+        return Objects.equals(atomicConstraint, that.atomicConstraint) &&
+            Objects.equals(matchFullString, that.matchFullString) &&
+            Objects.equals(negate, that.negate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(atomicConstraint, matchFullString, negate);
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/FieldSpecFactoryTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/FieldSpecFactoryTests.java
@@ -1,8 +1,7 @@
 package com.scottlogic.deg.generator.restrictions;
 
 import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
-import com.scottlogic.deg.generator.constraints.atomic.IsNullConstraint;
+import com.scottlogic.deg.generator.constraints.atomic.*;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import org.junit.Assert;
@@ -36,5 +35,224 @@ class FieldSpecFactoryTests {
         );
 
         Assert.assertEquals(fieldSpec, expectedFieldSpec);
+    }
+
+    @Test
+    void construct_stringHasLengthConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
+        StringHasLengthConstraint constraint = new StringHasLengthConstraint(
+            new Field("Test"),
+            10,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_stringHasLengthConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
+        ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
+            new StringHasLengthConstraint(
+                new Field("Test"),
+                10,
+                null
+            )
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_twoInstancesOfStringHasLengthConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
+        StringHasLengthConstraint firstConstraint = new StringHasLengthConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        StringHasLengthConstraint secondConstraint = new StringHasLengthConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_stringHasLengthConstraintInstancesAreNotEqual_returnsDifferentStringGeneratorInstances() {
+        StringHasLengthConstraint firstConstraint = new StringHasLengthConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        StringHasLengthConstraint secondConstraint = new StringHasLengthConstraint(
+            new Field("Different"),
+            20,
+            null
+        );
+
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertNotSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringLongerThanConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
+        IsStringLongerThanConstraint constraint = new IsStringLongerThanConstraint(
+            new Field("Test"),
+            15,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringLongerThanConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
+        ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
+            new IsStringLongerThanConstraint(
+                new Field("Test"),
+                10,
+                null
+            )
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_twoInstancesOfIsStringLongerThanConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
+        IsStringLongerThanConstraint firstConstraint = new IsStringLongerThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        IsStringLongerThanConstraint secondConstraint = new IsStringLongerThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringLongerThanConstraintInstancesAreNotEqual_returnsDifferentStringGeneratorInstances() {
+        IsStringLongerThanConstraint firstConstraint = new IsStringLongerThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        IsStringLongerThanConstraint secondConstraint = new IsStringLongerThanConstraint(
+            new Field("Different"),
+            20,
+            null
+        );
+
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertNotSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringShorterThanConstraintRetrievedTwice_returnsTheSameGeneratorInstance() {
+        IsStringShorterThanConstraint constraint = new IsStringShorterThanConstraint(
+            new Field("Test"),
+            25,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringShorterThanConstraintViolatedTwice_returnsTheSameGeneratorInstance() {
+        ViolatedAtomicConstraint constraint = new ViolatedAtomicConstraint(
+            new IsStringShorterThanConstraint(
+                new Field("Test"),
+                10,
+                null
+            )
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(constraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(constraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_twoInstancesOfIsStringShorterThanConstraintCalledWithEqualValues_returnsTheSameGeneratorInstance() {
+        IsStringShorterThanConstraint firstConstraint = new IsStringShorterThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        IsStringShorterThanConstraint secondConstraint = new IsStringShorterThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
+    }
+
+    @Test
+    void construct_isStringShorterThanConstraintInstancesAreNotEqual_returnsDifferentStringGeneratorInstances() {
+        IsStringShorterThanConstraint firstConstraint = new IsStringShorterThanConstraint(
+            new Field("Test"),
+            20,
+            null
+        );
+        IsStringShorterThanConstraint secondConstraint = new IsStringShorterThanConstraint(
+            new Field("Different"),
+            20,
+            null
+        );
+
+        FieldSpecFactory fieldSpecFactory = new FieldSpecFactory();
+
+        final FieldSpec firstInstance = fieldSpecFactory.construct(firstConstraint);
+        final FieldSpec secondInstance = fieldSpecFactory.construct(secondConstraint);
+
+        Assert.assertNotSame(firstInstance.getStringRestrictions().stringGenerator, secondInstance.getStringRestrictions().stringGenerator);
     }
 }


### PR DESCRIPTION
#### Description
Adds a change to the FieldSpecFactory to optomise the construction of a Regex String generator

#### Changes
Creates a cache in the FieldSpecFactory to retrieve generators that have already been created with an associated atomic constraint.

#### Issue
Associated with #449 