### PR TITLE
aValid changes when merging with other textual constraints

### DIFF
--- a/docs/EpistemicConstraints.md
+++ b/docs/EpistemicConstraints.md
@@ -102,6 +102,8 @@ Is satisfied if `field` is a string with length less than `value`.
 Is satisfied if `field` is a valid `value`, in this case a valid ISIN code. Possible options for `value` are:
 * ISIN
 
+**NOTE**: This constraint cannot be combined with any other textual constraint, doing so will mean no string data is created. See [Frequently asked questions](FrequentlyAskedQuestions.md) for more detail.
+
 ## Numeric constraints
 These constraints imply `ofType numeric`.
 

--- a/docs/FrequentlyAskedQuestions.md
+++ b/docs/FrequentlyAskedQuestions.md
@@ -67,3 +67,24 @@ Both of the above operators will explicitly deny the inclusion of `null`, theref
 All fields permit the inclusion of the empty set (&#8709;) by default, to prevent the field from having a `null` emitted, ensure you use the `not(is null)` constraint.
 
 For more details see the [set restriction and generation](./../generator/docs/SetRestrictionAndGeneration.md) page.
+
+## Why can I not combine `aValid` and other textual constraints
+
+If a profile with these constraints exist, then no string values will be emitted:
+
+`aValid ISIN` & `longerThan 5`
+
+This is a limitation with the current implementation of the generator, there are plans to solve this issue - see [#487](https://github.com/ScottLogic/datahelix/issues/487) for progress. For now, combining the `aValid` constraint with any of following (textual) constraints will cause the generator to emit no strings.
+* `shorterThan`
+* `longerThan`
+* `matchingRegex`
+* `containingRegex`
+* `ofLength`
+
+Combining an `aValid` with any other constrains is still permitted including `inSet` and `equalTo` with a string value. Combining the use of both will ensure no string values are emitted.
+
+Valid examples are:
+* `aValid ISIN` & `inSet [ "GB0002634947", 123 ]` - will emit `null` and `"GB0002634947"`
+* `not(aValid ISIN)` & `inSet [ "GB0002634947", 123 ]` - will emit `null` and `123`
+* `aValid ISIN` & `equalTo "GB0002634947"` - will emit `null` and `"GB0002634947"`
+* `aValid ISIN` & `greaterThan 5` - will emit `null` and all valid ISIN codes

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/atomic/MatchesStandardConstraint.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/atomic/MatchesStandardConstraint.java
@@ -9,10 +9,10 @@ import java.util.Set;
 
 public class MatchesStandardConstraint implements AtomicConstraint {
     public final Field field;
-    public final StringGenerator standard; // TODO: Change this to an enum member; string generators shouldn't exist on this level
+    public final StandardConstraintTypes standard;
     private final Set<RuleInformation> rules;
 
-    public MatchesStandardConstraint(Field field, StringGenerator standard, Set<RuleInformation> rules) {
+    public MatchesStandardConstraint(Field field, StandardConstraintTypes standard, Set<RuleInformation> rules) {
         this.field = field;
         this.standard = standard;
         this.rules = rules;
@@ -54,3 +54,4 @@ public class MatchesStandardConstraint implements AtomicConstraint {
         return new MatchesStandardConstraint(this.field, this.standard, rules);
     }
 }
+

--- a/generator/src/main/java/com/scottlogic/deg/generator/constraints/atomic/StandardConstraintTypes.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/constraints/atomic/StandardConstraintTypes.java
@@ -1,0 +1,6 @@
+package com.scottlogic.deg.generator.constraints.atomic;
+
+public enum StandardConstraintTypes{
+    SEDOL,
+    ISIN
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -242,7 +242,8 @@ public class FieldSpecFactory {
     }
 
     private FieldSpec construct(MatchesStandardConstraint constraint, boolean negate, boolean violated) {
-        return construct(standardNameToStringGenerator.get(constraint.standard), negate, constraint, violated);
+        StringGenerator generator = standardNameToStringGenerator.get(constraint.standard);
+        return construct(negate ? generator.complement() : generator, negate, constraint, violated);
     }
 
     private FieldSpec construct(FormatConstraint constraint, boolean negate, boolean violated) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecFactory.java
@@ -2,22 +2,31 @@ package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.constraints.StringConstraintsCollection;
 import com.scottlogic.deg.generator.constraints.atomic.*;
+import com.scottlogic.deg.generator.generation.IsinStringGenerator;
 import com.scottlogic.deg.generator.generation.RegexStringGenerator;
-import com.scottlogic.deg.generator.restrictions.*;
+import com.scottlogic.deg.generator.generation.SedolStringGenerator;
 import com.scottlogic.deg.generator.generation.StringGenerator;
+import com.scottlogic.deg.generator.restrictions.*;
 import com.scottlogic.deg.generator.utils.NumberUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class FieldSpecFactory {
     private static Map<AtomicConstraintConstructTuple, StringGenerator> constraintToStringGeneratorMap = new HashMap<>();
+
+    private static final Map<StandardConstraintTypes, StringGenerator>
+        standardNameToStringGenerator = new HashMap<StandardConstraintTypes, StringGenerator>() {{
+            put(StandardConstraintTypes.ISIN, new IsinStringGenerator());
+            put(StandardConstraintTypes.SEDOL, new SedolStringGenerator());
+    }};
 
     public FieldSpec construct(AtomicConstraint constraint) {
         return construct(constraint, false, false);
@@ -233,7 +242,7 @@ public class FieldSpecFactory {
     }
 
     private FieldSpec construct(MatchesStandardConstraint constraint, boolean negate, boolean violated) {
-        return construct(constraint.standard, negate, constraint, violated);
+        return construct(standardNameToStringGenerator.get(constraint.standard), negate, constraint, violated);
     }
 
     private FieldSpec construct(FormatConstraint constraint, boolean negate, boolean violated) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/IsinStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/IsinStringGenerator.java
@@ -25,7 +25,9 @@ public class IsinStringGenerator implements StringGenerator {
 
     @Override
     public StringGenerator intersect(StringGenerator stringGenerator) {
-        throw new UnsupportedOperationException();
+        return new NoStringsStringGenerator(
+            RegexStringGenerator.intersectRepresentation(stringGenerator.toString(), "<ISIN>")
+        );
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/IsinStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/IsinStringGenerator.java
@@ -49,7 +49,8 @@ public class IsinStringGenerator implements StringGenerator {
 
     @Override
     public boolean match(String subject) {
-        return IsinUtils.isValidIsin(subject);
+        boolean matches = IsinUtils.isValidIsin(subject);
+        return matches != isNegated;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/SedolStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/SedolStringGenerator.java
@@ -55,7 +55,8 @@ public class SedolStringGenerator implements StringGenerator {
 
     @Override
     public boolean match(String subject) {
-        return IsinUtils.isValidSedolNsin(subject);
+        boolean matches = IsinUtils.isValidSedolNsin(subject);
+        return matches != negate;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/SedolStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/SedolStringGenerator.java
@@ -33,7 +33,9 @@ public class SedolStringGenerator implements StringGenerator {
 
     @Override
     public StringGenerator intersect(StringGenerator stringGenerator) {
-        return this;
+        return new NoStringsStringGenerator(
+            RegexStringGenerator.intersectRepresentation(stringGenerator.toString(), "<SEDOL>")
+        );
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookup.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookup.java
@@ -16,9 +16,6 @@ public class AtomicConstraintReaderLookup {
     private static final Map<String, ConstraintReader> typeCodeToSpecificReader;
 
     static {
-        Map<String, StringGenerator> standardNameToStringGenerator = new HashMap<>();
-        standardNameToStringGenerator.put("ISIN", new IsinStringGenerator());
-
         typeCodeToSpecificReader = new HashMap<>();
 
         add(AtomicConstraintType.FORMATTEDAS.toString(),
@@ -60,7 +57,7 @@ public class AtomicConstraintReaderLookup {
                 (dto, fields, rules) ->
                     new MatchesStandardConstraint(
                         fields.getByName(dto.field),
-                        standardNameToStringGenerator.get((String) dto.value),
+                        StandardConstraintTypes.valueOf((String) dto.value),
                         rules
                     ));
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/ContainsRegexConstraintTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/ContainsRegexConstraintTests.java
@@ -1,27 +1,26 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.constraints.atomic;
 
 import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.constraints.atomic.IsGranularToConstraint;
+import com.scottlogic.deg.generator.constraints.atomic.ContainsRegexConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
-import com.scottlogic.deg.generator.restrictions.ParsedGranularity;
 import com.scottlogic.deg.schemas.v3.RuleDTO;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class IsGranularToConstraintTest {
+public class ContainsRegexConstraintTests {
 
     @Test
     public void testConstraintIsEqual() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField");
-        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
-        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(0.1)), rules());
+        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
+        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abc]"), rules());
         Assert.assertThat(constraint1, equalTo(constraint2));
     }
 
@@ -29,8 +28,8 @@ public class IsGranularToConstraintTest {
     public void testConstraintIsNotEqualDueToField() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField2");
-        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
-        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(0.1)), rules());
+        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
+        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abc]"), rules());
         Assert.assertNotEquals(constraint1, constraint2);
     }
 
@@ -38,8 +37,8 @@ public class IsGranularToConstraintTest {
     public void testConstraintIsNotEqualDueToValue() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField");
-        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
-        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(1.0)), rules());
+        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
+        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abcd]"), rules());
         Assert.assertNotEquals(constraint1, constraint2);
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/IsGranularToConstraintTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/IsGranularToConstraintTests.java
@@ -1,26 +1,27 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.constraints.atomic;
 
 import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.constraints.atomic.ContainsRegexConstraint;
+import com.scottlogic.deg.generator.constraints.atomic.IsGranularToConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
+import com.scottlogic.deg.generator.restrictions.ParsedGranularity;
 import com.scottlogic.deg.schemas.v3.RuleDTO;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class ContainsRegexConstraintTest {
+public class IsGranularToConstraintTests {
 
     @Test
     public void testConstraintIsEqual() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField");
-        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
-        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abc]"), rules());
+        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
+        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(0.1)), rules());
         Assert.assertThat(constraint1, equalTo(constraint2));
     }
 
@@ -28,8 +29,8 @@ public class ContainsRegexConstraintTest {
     public void testConstraintIsNotEqualDueToField() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField2");
-        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
-        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abc]"), rules());
+        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
+        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(0.1)), rules());
         Assert.assertNotEquals(constraint1, constraint2);
     }
 
@@ -37,8 +38,8 @@ public class ContainsRegexConstraintTest {
     public void testConstraintIsNotEqualDueToValue() {
         Field field1 = new Field("TestField");
         Field field2 = new Field("TestField");
-        ContainsRegexConstraint constraint1 = new ContainsRegexConstraint(field1, Pattern.compile("[abc]"), rules());
-        ContainsRegexConstraint constraint2 = new ContainsRegexConstraint(field2, Pattern.compile("[abcd]"), rules());
+        IsGranularToConstraint constraint1 = new IsGranularToConstraint(field1, new ParsedGranularity(new BigDecimal(0.1)), rules());
+        IsGranularToConstraint constraint2 = new IsGranularToConstraint(field2, new ParsedGranularity(new BigDecimal(1.0)), rules());
         Assert.assertNotEquals(constraint1, constraint2);
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/IsInSetConstraintTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/constraints/atomic/IsInSetConstraintTests.java
@@ -1,4 +1,4 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.constraints.atomic;
 
 import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.constraints.atomic.IsInSetConstraint;

--- a/generator/src/test/java/com/scottlogic/deg/generator/constraints/grammatical/AndConstraintTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/constraints/grammatical/AndConstraintTests.java
@@ -1,8 +1,7 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.constraints.grammatical;
 
 import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.constraints.atomic.IsNullConstraint;
-import com.scottlogic.deg.generator.constraints.grammatical.AndConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
 import com.scottlogic.deg.schemas.v3.RuleDTO;
 import org.junit.Assert;
@@ -13,7 +12,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AndConstraintTest {
+public class AndConstraintTests {
 
     @Test
     public void testConstraintIsEqual() {

--- a/generator/src/test/java/com/scottlogic/deg/generator/constraints/grammatical/NotConstraintTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/constraints/grammatical/NotConstraintTests.java
@@ -1,6 +1,7 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.constraints.grammatical;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.IsInSetConstraint;
 import com.scottlogic.deg.generator.constraints.atomic.IsNullConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
@@ -13,7 +14,7 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class NotConstraintTest {
+public class NotConstraintTests {
 
     @Test
     public void testConstraintIsEqual() {

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
@@ -274,72 +274,73 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | foo  |
       | null |
 
-  @ignore
   Scenario: Running an 'aValid' request alongside a non-contradicting aValid constraint should be successful
     Given foo is a valid "ISIN"
     And foo is a valid "ISIN"
     And foo is in set:
       | "GB0002634946" |
     Then the following data should be generated:
+      | foo            |
+      | null           |
       | "GB0002634946" |
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a greaterThan constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is greater than 0
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a greaterThanOrEqualTo constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is greater than or equal to 1
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a lessThan constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is less than 13
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a lessThanOrEqualTo constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is less than or equal to 12
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a granularTo constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is granular to 1
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside an after constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is after 2018-09-01T00:00:00.000
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside an afterOrAt constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is after or at 2018-09-01T00:00:00.000
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a before constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is before 2018-09-01T00:00:00.000
     Then I am presented with an error message
     And no data is created
 
-  @ignore
+  @ignore # profile is unconstrained, generation would run 'forever', all valid ISIN codes can be generated
   Scenario: Running an 'aValid' request alongside a beforeOrAt constraint should fail with an error message
     Given foo is a valid "ISIN"
     And foo is before or at 2018-09-01T00:00:00.000
@@ -397,8 +398,7 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | null           |
       | "GB0002634946" |
 
-  @ignore
-  Scenario: Running an 'aValid' request as part of a contradicting allOf constraint should fail with an error message
+  Scenario: Running an 'aValid' request as part of a contradicting allOf constraint should only emit null
     Given there is a constraint:
       """
         { "allOf": [
@@ -406,4 +406,6 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
            { "field": "foo", "is": "equalTo", "value": "GB0002634947" }
         ]}
       """
-    Then no data is created
+    Then the following data should be generated:
+      | foo            |
+      | null           |

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
@@ -346,7 +346,6 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
     Then I am presented with an error message
     And no data is created
 
-  @ignore @bug
   Scenario: Running an 'aValid' request with a not constraint should be successful
     Given foo is anything but a valid "ISIN"
     And foo is in set:
@@ -356,9 +355,8 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | "GB0002634946"            |
     Then the following data should be generated:
       | foo                       |
+      | null                      |
       | "333"                     |
-      | 123                       |
-      | 2018-09-01T00:00:00.000   |
     And the following data should not be included in what is generated:
       | foo            |
       | "GB0002634946" |

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
@@ -163,11 +163,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | /[A-Z0-9]/          |
 
 
-  Scenario Outline: Running an 'aValid' request alongside a contradicting matchingRegex constraint should fail with an error message
+  Scenario Outline: Running an 'aValid' request alongside a contradicting matchingRegex constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is matching regex <regex>
-    Then I am presented with an error message
-    And no data is created
+    And the following data should be generated:
+      | foo |
+      | null |
     Examples:
       | regex               |
       | /GB0002634947/      |
@@ -199,11 +200,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | /[A-Z]{2}[0-9]{9}/  |
       | /[A-Z0-9]{11}/      |
 
-  Scenario Outline: Running an 'aValid' request alongside a contradicting containingRegex constraint should fail with an error message
+  Scenario Outline: Running an 'aValid' request alongside a contradicting containingRegex constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is containing regex <regex>
-    Then I am presented with an error message
-    And no data is created
+    And the following data should be generated:
+      | foo |
+      | null |
     Examples:
       | regex               |
       | /GB0002634947/      |
@@ -224,11 +226,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | foo            |
       | "GB0002634946" |
 
-  Scenario Outline: Running an 'aValid' request alongside a contradicting ofLength constraint should fail with an error message
+  Scenario Outline: Running an 'aValid' request alongside a contradicting ofLength constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is of length <length>
-    Then I am presented with an error message
-    And no data is created
+    And the following data should be generated:
+      | foo |
+      | null |
     Examples:
     | length |
     | 11     |
@@ -252,11 +255,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | 1      |
       | 11     |
 
-  Scenario: Running an 'aValid' request alongside a contradicting longerThan constraint should fail with an error message
+  Scenario: Running an 'aValid' request alongside a contradicting longerThan constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is longer than 12
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
   @ignore @bug
   Scenario: Running an 'aValid' request alongside a non-contradicting shorterThan constraint should be successful
@@ -267,11 +271,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
     Then the following data should be generated:
       | "GB0002634946" |
 
-  Scenario: Running an 'aValid' request alongside a contradicting shorterThan constraint should fail with an error message
+  Scenario: Running an 'aValid' request alongside a contradicting shorterThan constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is shorter than 12
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
   @ignore @bug
   Scenario: Running an 'aValid' request alongside a non-contradicting aValid constraint should be successful

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/AValid.feature
@@ -110,12 +110,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | null           |
       | "GB0002634946" |
 
-  @ignore
-  Scenario: Running an 'aValid' request alongside a contradicting equalTo constraint should fail with an error message
+  Scenario: Running an 'aValid' request alongside a contradicting equalTo constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is equal to "GB00026349"
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
   Scenario: Running an 'aValid' request alongside a non-contradicting inSet constraint should be successful
     Given foo is a valid "ISIN"
@@ -126,8 +126,7 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | null           |
       | "GB0002634946" |
 
-  @ignore
-  Scenario: Running an 'aValid' request alongside a contradicting inSet constraint should fail with an error message
+  Scenario: Running an 'aValid' request alongside a contradicting inSet constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is in set:
       | "GB0002634947"  |
@@ -138,23 +137,23 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | "400002634946"  |
       | "GBP002634946"  |
       | "GB000263494z"  |
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
-  @ignore
-  Scenario: Running an 'aValid' request alongside a null constraint should fail with an error message
+  Scenario: Running an 'aValid' request alongside a null constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is null
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
-  @ignore @bug
-  Scenario Outline: Running an 'aValid' request alongside a non-contradicting matchingRegex constraint should be successful
+  Scenario Outline: Running an 'aValid' request alongside a non-contradicting matchingRegex constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is matching regex <regex>
-    Then the following data should be included in what is generated:
-      | foo            |
-      | "GB0002634946" |
+    Then the following data should be generated:
+      | foo |
+      | null |
     Examples:
       | regex               |
       | /GB0002634946/      |
@@ -180,13 +179,12 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | /[A-Z0-9]{13}/      |
       | /[A-Z0-9]{11}/      |
 
-  @ignore @bug
-  Scenario Outline: Running an 'aValid' request alongside a non-contradicting containingRegex constraint should be successful
+  Scenario Outline: Running an 'aValid' request alongside a non-contradicting containingRegex constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is containing regex <regex>
-    Then the following data should be included in what is generated:
-      | foo            |
-      | "GB0002634946" |
+    Then the following data should be generated:
+      | foo |
+      | null |
     Examples:
       | regex               |
       | /GB0002634946/      |
@@ -216,15 +214,14 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | /GBZ/               |
       | /0002634947/        |
 
-  @ignore @bug
-  Scenario: Running an 'aValid' request alongside a non-contradiction ofLength constraint should be successful
+  Scenario: Running an 'aValid' request alongside a non-contradicting ofLength constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is of length 12
     And foo is in set:
       | "GB0002634946" |
     Then the following data should be generated:
       | foo            |
-      | "GB0002634946" |
+      | null |
 
   Scenario Outline: Running an 'aValid' request alongside a contradicting ofLength constraint should only emit null
     Given foo is a valid "ISIN"
@@ -240,15 +237,14 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
     | 0      |
     | 9999   |
 
-  @ignore @bug
-  Scenario Outline: Running an 'aValid' request alongside a non-contradicting longerThan constraint should be successful
+  Scenario Outline: Running an 'aValid' request alongside a non-contradicting longerThan constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is longer than <length>
     And foo is in set:
       | "GB0002634946" |
     Then the following data should be generated:
       | foo            |
-      | "GB0002634946" |
+      | null |
     Examples:
       | length |
       | 0      |
@@ -262,23 +258,23 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
       | foo |
       | null |
 
-  @ignore @bug
-  Scenario: Running an 'aValid' request alongside a non-contradicting shorterThan constraint should be successful
+  Scenario: Running an 'aValid' request alongside a non-contradicting shorterThan constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is shorter than 13
     And foo is in set:
       | "GB0002634946" |
     Then the following data should be generated:
-      | "GB0002634946" |
+      | foo  |
+      | null |
 
   Scenario: Running an 'aValid' request alongside a contradicting shorterThan constraint should only emit null
     Given foo is a valid "ISIN"
     And foo is shorter than 12
     Then the following data should be generated:
-      | foo |
+      | foo  |
       | null |
 
-  @ignore @bug
+  @ignore
   Scenario: Running an 'aValid' request alongside a non-contradicting aValid constraint should be successful
     Given foo is a valid "ISIN"
     And foo is a valid "ISIN"
@@ -412,5 +408,4 @@ Scenario: Running an 'aValid' request that includes a value of a string "ISIN" s
            { "field": "foo", "is": "equalTo", "value": "GB0002634947" }
         ]}
       """
-    Then I am presented with an error message
-    And no data is created
+    Then no data is created

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/If.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/If.feature
@@ -1583,7 +1583,6 @@ Scenario: Running an if request that contains a contradictory shorterThan constr
        | foo    | bar    |
        | "dddd" | "4444" |
 
-@ignore
 Scenario: Running an if request that contains a non contradictory aValid constraint within its if statement should be successful
        Given foo is in set:
          | "GB0002634946" |

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/If.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/If.feature
@@ -1667,7 +1667,6 @@ Scenario: Running an if request that contains a non contradictory aValid constra
        | "ccc"          | "GB0002634946" |
        | "dddd"         | "GB0002634946" |
 
-@ignore
 Scenario: Running an if request that contains a contradictory aValid constraint within its if statement should be successful
        Given foo is in set:
          | "aa"   |
@@ -1691,12 +1690,11 @@ Scenario: Running an if request that contains a contradictory aValid constraint 
        """
      Then the following data should be generated:
        | foo    | bar   |
-       | "a"    | "333" |
+       | "aa"   | "333" |
        | "bb"   | "333" |
        | "ccc"  | "333" |
        | "dddd" | "333" |
 
-@ignore
 Scenario: Running an if request that contains a contradictory aValid constraint within its then statement should be successful
        Given foo is in set:
          | "aa"   |
@@ -1720,7 +1718,7 @@ Scenario: Running an if request that contains a contradictory aValid constraint 
        """
      Then the following data should be generated:
        | foo    | bar   |
-       | "a"    | "333" |
+       | "aa"   | "333" |
        | "bb"   | "333" |
        | "dddd" | "333" |
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
@@ -436,11 +436,12 @@ Scenario: Running a 'matchingRegex' request alongside a non-contradicting aValid
        | null           |
        | "GB0000000009" |
 
-Scenario: Running a 'matchingRegex' request alongside a contradicting aValid constraint should fail with an error message
+Scenario: Running a 'matchingRegex' request alongside a contradicting aValid constraint should only emit null
        Given foo is matching regex /[b]{2}/
        And foo is a valid "ISIN"
-     Then I am presented with an error message
-       And no data is created
+       Then the following data should be generated:
+        | foo |
+        | null |
 
 @ignore
 Scenario: Running a 'matchingRegex' request alongside a greaterThan constraint should fail with an error message

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/MatchingRegex.feature
@@ -427,14 +427,12 @@ Scenario: Running a 'matchingRegex' request alongside a contradicting shorterTha
      Then I am presented with an error message
        And no data is created
 
-@ignore
-Scenario: Running a 'matchingRegex' request alongside a non-contradicting aValid constraint should be successful
+Scenario: Running a 'matchingRegex' request alongside a non-contradicting aValid constraint should only emit null
        Given foo is matching regex /[0-9A-Za-z]{12}/
        And foo is a valid "ISIN"
      Then the following data should be included in what is generated:
        | foo            |
        | null           |
-       | "GB0000000009" |
 
 Scenario: Running a 'matchingRegex' request alongside a contradicting aValid constraint should only emit null
        Given foo is matching regex /[b]{2}/

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/OfLength.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/OfLength.feature
@@ -591,15 +591,16 @@ Feature: User can specify the length of generated string data using 'ofLength'
       | "22" |
 
 
-  Scenario: Running an 'ofLength' request alongside a contradicting aValid constraint should fail with an error message
+  Scenario: Running an 'ofLength' request alongside a contradicting aValid constraint should only emit null
     Given foo is of length 2
     And foo is a valid "ISIN"
     And foo is in set:
       | "AU0000XVGZA3" |
       | "US0378331005" |
       | "22"           |
-    Then I am presented with an error message
-    And no data is created
+    Then the following data should be generated:
+      | foo |
+      | null |
 
 
   @ignore

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/IsinStringGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/IsinStringGeneratorTests.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.generator.generation;
 import com.scottlogic.deg.generator.utils.IsinUtils;
 import com.scottlogic.deg.generator.utils.IterableAsStream;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
@@ -13,7 +14,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class IsinStringGeneratorTest {
+public class IsinStringGeneratorTests {
 
     @Test
     public void shouldEndAllIsinsWithValidCheckDigit() {
@@ -85,5 +86,41 @@ public class IsinStringGeneratorTest {
             final String nextIsin = allIsins.next();
             assertThat(IsinUtils.isValidIsin(nextIsin), is(false));
         }
+    }
+
+    @Test
+    public void shouldMatchAValidIsinCodeWhenNotNegated(){
+        StringGenerator isinGenerator = new IsinStringGenerator();
+
+        boolean matches = isinGenerator.match("GB0002634946");
+
+        Assert.assertTrue(matches);
+    }
+
+    @Test
+    public void shouldNotMatchAnInvalidIsinCodeWhenNotNegated(){
+        StringGenerator isinGenerator = new IsinStringGenerator();
+
+        boolean matches = isinGenerator.match("not an isin");
+
+        Assert.assertFalse(matches);
+    }
+
+    @Test
+    public void shouldNotMatchAValidIsinCodeWhenNegated(){
+        StringGenerator isinGenerator = new IsinStringGenerator().complement();
+
+        boolean matches = isinGenerator.match("GB0002634946");
+
+        Assert.assertFalse(matches);
+    }
+
+    @Test
+    public void shouldMatchAnInvalidIsinCodeWhenNegated(){
+        StringGenerator isinGenerator = new IsinStringGenerator().complement();
+
+        boolean matches = isinGenerator.match("not an isin");
+
+        Assert.assertTrue(matches);
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/SedolStringGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/SedolStringGeneratorTests.java
@@ -1,0 +1,42 @@
+package com.scottlogic.deg.generator.generation;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class SedolStringGeneratorTests {
+    @Test
+    public void shouldMatchAValidSedolCodeWhenNotNegated(){
+        StringGenerator SedolGenerator = new SedolStringGenerator();
+
+        boolean matches = SedolGenerator.match("002634946");
+
+        Assert.assertTrue(matches);
+    }
+
+    @Test
+    public void shouldNotMatchAnInvalidSedolCodeWhenNotNegated(){
+        StringGenerator SedolGenerator = new SedolStringGenerator();
+
+        boolean matches = SedolGenerator.match("not a sedol");
+
+        Assert.assertFalse(matches);
+    }
+
+    @Test
+    public void shouldNotMatchAValidSedolCodeWhenNegated(){
+        StringGenerator SedolGenerator = new SedolStringGenerator().complement();
+
+        boolean matches = SedolGenerator.match("002634946");
+
+        Assert.assertFalse(matches);
+    }
+
+    @Test
+    public void shouldMatchAnInvalidSedolCodeWhenNegated(){
+        StringGenerator SedolGenerator = new SedolStringGenerator().complement();
+
+        boolean matches = SedolGenerator.match("not a sedol");
+
+        Assert.assertTrue(matches);
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookupTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookupTests.java
@@ -1,12 +1,9 @@
-package com.scottlogic.deg.generator.constraints;
+package com.scottlogic.deg.generator.inputs;
 
 import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.ProfileFields;
+import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.*;
-import com.scottlogic.deg.generator.inputs.AtomicConstraintReaderLookup;
-import com.scottlogic.deg.generator.inputs.ConstraintReader;
-import com.scottlogic.deg.generator.inputs.InvalidProfileException;
-import com.scottlogic.deg.generator.inputs.RuleInformation;
 import com.scottlogic.deg.schemas.v3.AtomicConstraintType;
 import com.scottlogic.deg.schemas.v3.ConstraintDTO;
 import com.scottlogic.deg.schemas.v3.RuleDTO;
@@ -26,7 +23,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class AtomicConstraintTests {
+public class AtomicConstraintReaderLookupTests {
 
     AtomicConstraintReaderLookup atomicConstraintReaderLookup;
     ProfileFields profileFields;


### PR DESCRIPTION
#### Description
The `aValid` constraint when combined with other textual constraints throws an error.

#### Changes
- Don't throw an error when merging an `aValid` constraint with another textual constraint, instead emit no string values
- Updated documentation to cover this change, introduced FAQ to explain workable scenarios and link to issue created to implement a fix (#487)
- Fixed issues where negating an `aValid` had no effect, valid ISIN (and SEDOL) codes were still emitted, tests added
- Restored (un-ignored) tests that now pass due to this change
- Test classes moved to matching packages as in production module
- Refactored `MatchingStandardConstraint` to not hold onto a string generator, as per comment and to resolve negation issue

#### Additional notes
This is a 'temporary' fix to ensure that some data can be generated in these scenarios. It should be possible - but require lots more thought and discussion - to solve this problem, but its not a priority for now.

See comments in #246 for more detail on the issue

#### Issue
Resolves #246 
Resolves #247 
Resolves #339 