### PR TITLE
Fix for contradictory before/after generating invalid dates

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
@@ -18,6 +18,10 @@ public class DateTimeRestrictionsMerger {
         merged.min = getMergedLimitStructure(MergeLimit.MIN, left.min, right.min);
         merged.max = getMergedLimitStructure(MergeLimit.MAX, left.max, right.max);
 
+        if (merged.min.getLimit().isAfter(merged.max.getLimit())) {
+            return null;
+        }
+
         return merged;
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
@@ -1,0 +1,111 @@
+package com.scottlogic.deg.generator.restrictions;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+class DateTimeRestrictionsMergerTests {
+    @Test
+    void merge_dateTimeRestrictionsAreBothNull_returnsNull() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+
+        DateTimeRestrictions result = merger.merge(null, null);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    void merge_leftIsNullAndRightHasAValue_returnsRight() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+        DateTimeRestrictions right = new DateTimeRestrictions();
+
+        DateTimeRestrictions result = merger.merge(null, right);
+
+        Assert.assertSame(right, result);
+    }
+
+    @Test
+    void merge_rightIsNullAndLeftHasAValue_returnsLeft() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+        DateTimeRestrictions left = new DateTimeRestrictions();
+
+        DateTimeRestrictions result = merger.merge(left, null);
+
+        Assert.assertSame(left, result);
+    }
+
+    @Test
+    void merge_leftHasMinAndRightHasMax_returnsDateTimeRestrictionsWithMergedMinAndMax() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now().minusDays(7), false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now(), false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+
+        DateTimeRestrictions result = merger.merge(left, right);
+
+        Assert.assertEquals(minDateTimeLimit, result.min);
+        Assert.assertEquals(maxDateTimeLimit, result.max);
+    }
+
+    @Test
+    void merge_leftHasMaxAndRightHasMin_returnsDateTimeRestrictionsWithMergedMinAndMax() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now().minusDays(7), false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now(), false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+
+        DateTimeRestrictions result = merger.merge(left, right);
+
+        Assert.assertEquals(minDateTimeLimit, result.min);
+        Assert.assertEquals(maxDateTimeLimit, result.max);
+    }
+
+    @Test
+    void merge_leftHasMinGreaterThanRightMax_returnsNull() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now(), false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now().minusDays(10), false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+
+        DateTimeRestrictions result = merger.merge(left, right);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    void merge_rightHasMinGreaterThanLeftMax_returnsNull() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now(), false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            LocalDateTime.now().minusDays(10), false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+
+        DateTimeRestrictions result = merger.merge(left, right);
+
+        Assert.assertNull(result);
+    }
+}


### PR DESCRIPTION
#### Description
Includes a fix for when a contradictory before/after rule has been supplied to the profile which would still output the dates described in the rule. This PR also includes some extra tests since we didn't have any for the DateTimeRestrictionsMerger class

#### Changes

- A check in the DateTimeRestrictionsMerger to detect if the merged object contains an invalid date range
- Tests supporting the new functionality
- Tests for some of the existing functionality

#### Issue
Resolves #324 