### PR TITLE
Use flatMap shim as widely as possible

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/analysis/FieldDependencyAnalyser.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/analysis/FieldDependencyAnalyser.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.analysis;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.constraints.grammatical.ConditionalConstraint;
 import com.scottlogic.deg.generator.constraints.Constraint;
@@ -103,8 +104,7 @@ public class FieldDependencyAnalyser {
     }
 
     private Stream<Constraint> constraintsFromProfile(Profile profile){
-        return profile.rules.stream()
-            .flatMap(rule -> rule.constraints.stream());
+        return FlatMappingSpliterator.flatMap(profile.rules.stream(), rule -> rule.constraints.stream());
     }
 
     private Stream<ConditionalConstraint> conditionalConstraintsFromProfile(Profile profile){

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/MostProlificConstraintOptimiser.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/MostProlificConstraintOptimiser.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.decisiontree;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.constraints.atomic.NotConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
@@ -126,10 +127,12 @@ public class MostProlificConstraintOptimiser implements DecisionTreeOptimiser {
     }
 
     private AtomicConstraint getMostProlificAtomicConstraint(Collection<DecisionNode> decisions) {
-        Map<AtomicConstraint, List<AtomicConstraint>> decisionConstraints = decisions
-            .stream()
-            .flatMap(dn -> dn.getOptions().stream())
-            .flatMap(option -> option.getAtomicConstraints().stream())
+        Map<AtomicConstraint, List<AtomicConstraint>> decisionConstraints =
+            FlatMappingSpliterator.flatMap(
+                FlatMappingSpliterator.flatMap(
+                    decisions.stream(),
+                    dn -> dn.getOptions().stream()),
+                option -> option.getAtomicConstraints().stream())
             .collect(Collectors.groupingBy(Function.identity()));
 
         Comparator<Map.Entry<AtomicConstraint, List<AtomicConstraint>>> comparator = Comparator
@@ -148,9 +151,9 @@ public class MostProlificConstraintOptimiser implements DecisionTreeOptimiser {
     }
 
     private AtomicConstraint getAtomicConstraintWithAllRules(List<AtomicConstraint> identicalAtomicConstraints) {
-        Set<RuleInformation> rules = identicalAtomicConstraints
-            .stream()
-            .flatMap(ac -> ac.getRules().stream())
+        Set<RuleInformation> rules = FlatMappingSpliterator.flatMap(identicalAtomicConstraints
+            .stream(),
+            ac -> ac.getRules().stream())
             .collect(Collectors.toSet());
 
         AtomicConstraint firstAtomicConstraint = identicalAtomicConstraints.iterator().next();

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ProfileDecisionTreeFactory.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/ProfileDecisionTreeFactory.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.decisiontree;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.Rule;
 import com.scottlogic.deg.generator.constraints.*;
@@ -78,8 +79,8 @@ public class ProfileDecisionTreeFactory implements DecisionTreeFactory {
     }
 
     private ConstraintNode convertRule(Rule rule) {
-        Iterator<ConstraintNode> rootConstraintNodeFragments = rule.constraints.stream()
-            .flatMap(c -> convertConstraint(c).stream())
+        Iterator<ConstraintNode> rootConstraintNodeFragments = FlatMappingSpliterator.flatMap(rule.constraints.stream(),
+            c -> convertConstraint(c).stream())
             .iterator();
 
         return ConstraintNode.merge(rootConstraintNodeFragments);
@@ -198,8 +199,8 @@ public class ProfileDecisionTreeFactory implements DecisionTreeFactory {
         else if (constraintToConvert instanceof AndConstraint) {
             Collection<Constraint> subConstraints = ((AndConstraint) constraintToConvert).subConstraints;
 
-            return subConstraints.stream()
-                .flatMap(c -> convertConstraint(c).stream())
+            return FlatMappingSpliterator.flatMap(subConstraints.stream(),
+                c -> convertConstraint(c).stream())
                 .collect(Collectors.toList());
         }
         // OR(X, Y, Z) becomes a decision node

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/TreeConstraintNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/TreeConstraintNode.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.decisiontree;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 
@@ -151,8 +152,9 @@ public final class TreeConstraintNode implements ConstraintNode {
 
     @Override
     public ConstraintNode markNode(NodeMarking marking) {
-        Set<NodeMarking> newMarkings = Stream.of(Collections.singleton(marking), this.nodeMarkings)
-            .flatMap(Collection::stream)
+        Set<NodeMarking> newMarkings = FlatMappingSpliterator.flatMap(
+            Stream.of(Collections.singleton(marking), this.nodeMarkings),
+            Collection::stream)
             .collect(Collectors.toSet());
         return new TreeConstraintNode(this.atomicConstraints, this.decisions, newMarkings);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/TreeDecisionNode.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/TreeDecisionNode.java
@@ -1,5 +1,7 @@
 package com.scottlogic.deg.generator.decisiontree;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
+
 import java.util.*;
 import java.util.Objects;
 import java.util.function.Function;
@@ -40,8 +42,9 @@ public final class TreeDecisionNode implements DecisionNode {
 
     @Override
     public DecisionNode markNode(NodeMarking marking) {
-        Set<NodeMarking> newMarkings = Stream.of(Collections.singleton(marking), this.nodeMarkings)
-            .flatMap(Collection::stream)
+        Set<NodeMarking> newMarkings = FlatMappingSpliterator.flatMap(
+                Stream.of(Collections.singleton(marking), this.nodeMarkings),
+                Collection::stream)
             .collect(Collectors.toSet());
         return new TreeDecisionNode(this.options, newMarkings);
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/tree_partitioning/ConstraintToFieldMapper.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/tree_partitioning/ConstraintToFieldMapper.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.decisiontree.tree_partitioning;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionTree;
 
@@ -39,11 +40,12 @@ class ConstraintToFieldMapper {
                 .stream()
                 .map(decision -> new ConstraintToFields(
                     new RootLevelConstraint(decision),
-                    decision
-                        .getOptions()
-                        .stream()
-                        .flatMap(this::mapConstraintToFields)
-                        .flatMap(objectField -> objectField.fields.stream())
+                    FlatMappingSpliterator.flatMap(
+                        FlatMappingSpliterator.flatMap(decision
+                            .getOptions()
+                            .stream(),
+                            this::mapConstraintToFields),
+                        objectField -> objectField.fields.stream())
                         .collect(Collectors.toSet()))
                 ));
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/tree_partitioning/RelatedFieldTreePartitioner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/decisiontree/tree_partitioning/RelatedFieldTreePartitioner.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.decisiontree.tree_partitioning;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.decisiontree.DecisionNode;
@@ -146,9 +147,9 @@ public class RelatedFieldTreePartitioner implements TreePartitioner {
         }
 
         private <T> Set<T> getFromAllPartitions(Set<Partition> partitions, Function<Partition, Set<T>> getter) {
-            return partitions
-                .stream()
-                .flatMap(partition -> getter.apply(partition).stream())
+            return FlatMappingSpliterator.flatMap(partitions
+                .stream(),
+                partition -> getter.apply(partition).stream())
                 .collect(Collectors.toSet());
         }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/StandardFieldValueSourceEvaluator.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.generation.field_value_sources.*;
@@ -66,8 +67,8 @@ public class StandardFieldValueSourceEvaluator implements FieldValueSourceEvalua
         // If we have values that must be included we need to check that those values are included in the whitelist
         if (mustContainRestriction != null) {
             whitelist = Stream.concat(whitelist,
-            getNotNullSetRestrictionFilterOnMustContainRestriction(mustContainRestriction)
-                .flatMap(o -> o.getSetRestrictions().getWhitelist().stream()));
+                FlatMappingSpliterator.flatMap(getNotNullSetRestrictionFilterOnMustContainRestriction(mustContainRestriction),
+                    o -> o.getSetRestrictions().getWhitelist().stream()));
         }
 
         if (mayBeNull(fieldSpec)) {
@@ -96,9 +97,9 @@ public class StandardFieldValueSourceEvaluator implements FieldValueSourceEvalua
             mustContainRestrictionFieldSpecs = mustContainRestrictionReducer.getReducedMustContainRestriction(fieldSpec);
         }
 
-        return mustContainRestrictionFieldSpecs.stream()
-            .map(fs -> getFieldValueSources(fs))
-            .flatMap(List::stream)
+        return FlatMappingSpliterator.flatMap(mustContainRestrictionFieldSpecs.stream()
+            .map(fs -> getFieldValueSources(fs)),
+            List::stream)
             .filter(x->!x.equals(nullOnlySource))
             .collect(Collectors.toList());
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combination_strategies/ExhaustiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combination_strategies/ExhaustiveCombinationStrategy.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation.combination_strategies;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 
 import java.util.*;
@@ -25,10 +26,10 @@ public class ExhaustiveCombinationStrategy implements CombinationStrategy {
         if (bagSequenceIndex < bagSequences.size()) {
             List<DataBag> nextStream = bagSequences.get(bagSequenceIndex);
 
-            return nextStream
+            return FlatMappingSpliterator.flatMap(nextStream
                 .stream()
-                .map(innerBag -> DataBag.merge(innerBag, accumulatingBag))
-                .flatMap(innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
+                .map(innerBag -> DataBag.merge(innerBag, accumulatingBag)),
+                innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
         }
         else
             return Stream.of(accumulatingBag);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combination_strategies/ReductiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combination_strategies/ReductiveCombinationStrategy.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation.combination_strategies;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.generation.databags.DataBag;
 import com.scottlogic.deg.generator.utils.RestartableIterator;
 
@@ -25,9 +26,9 @@ public class ReductiveCombinationStrategy implements CombinationStrategy {
             RestartableIterator<DataBag> nextStream = bagSequences.get(bagSequenceIndex);
             nextStream.restart();
 
-            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(nextStream, Spliterator.ORDERED),false)
-                .map(innerBag -> DataBag.merge(innerBag, accumulatingBag))
-                .flatMap(innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
+            return FlatMappingSpliterator.flatMap(StreamSupport.stream(Spliterators.spliteratorUnknownSize(nextStream, Spliterator.ORDERED),false)
+                .map(innerBag -> DataBag.merge(innerBag, accumulatingBag)),
+                innerBag -> next(innerBag, bagSequences, bagSequenceIndex + 1));
         }
         else
             return Stream.of(accumulatingBag);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/ConcatenatingDataBagSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/ConcatenatingDataBagSource.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation.databags;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.generation.GenerationConfig;
 
 import java.util.stream.Stream;
@@ -14,8 +15,9 @@ public class ConcatenatingDataBagSource implements DataBagSource {
 
     @Override
     public Stream<DataBag> generate(GenerationConfig generationConfig) {
-        return this.subSources
-            .map(source -> source.generate(generationConfig))
-            .flatMap(streamOfStreams -> streamOfStreams);
+        return FlatMappingSpliterator.flatMap(
+            this.subSources
+                .map(source -> source.generate(generationConfig)),
+            streamOfStreams -> streamOfStreams);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/DataBag.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/databags/DataBag.java
@@ -1,9 +1,6 @@
 package com.scottlogic.deg.generator.generation.databags;
 
-import com.scottlogic.deg.generator.DataBagValue;
-import com.scottlogic.deg.generator.DataBagValueSource;
-import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.ProfileFields;
+import com.scottlogic.deg.generator.*;
 import com.scottlogic.deg.generator.outputs.CellSource;
 import com.scottlogic.deg.generator.outputs.RowSource;
 
@@ -38,9 +35,9 @@ public class DataBag {
     public static DataBag merge(DataBag... bags) {
         Map<Field, DataBagValue> newFieldToValue = new HashMap<>();
 
-        Arrays.stream(bags)
-            .map(r -> r.fieldToValue.entrySet().stream())
-            .flatMap(entrySetStream -> entrySetStream)
+        FlatMappingSpliterator.flatMap(Arrays.stream(bags)
+            .map(r -> r.fieldToValue.entrySet().stream()),
+            entrySetStream -> entrySetStream)
             .forEach(entry -> {
                 if (newFieldToValue.containsKey(entry.getKey()))
                     throw new IllegalArgumentException("Databags can't be merged because they overlap on field " + entry.getKey().name);

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/field_value_sources/RealNumberFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/field_value_sources/RealNumberFieldValueSource.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation.field_value_sources;
 
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.restrictions.NumericLimit;
 import com.scottlogic.deg.generator.restrictions.NumericRestrictions;
 import com.scottlogic.deg.generator.utils.*;
@@ -76,11 +77,12 @@ public class RealNumberFieldValueSource implements FieldValueSource {
     @Override
     public Iterable<Object> generateInterestingValues() {
         return () -> new UpCastingIterator<>(
+            FlatMappingSpliterator.flatMap(
             Stream.of(
                 streamOf(() -> new RealNumberIterator()).limit(2),
                 streamOf(() -> new RealNumberIterator(new BigDecimal(0))).limit(1),
                 streamOf(() -> new RealNumberIterator(inclusiveUpperLimit.subtract(stepSize))).limit(2))
-            .flatMap(Function.identity())
+            , Function.identity())
             .distinct()
             .iterator());
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/CellSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/CellSource.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.generator.outputs;
 import com.scottlogic.deg.generator.DataBagValue;
 import com.scottlogic.deg.generator.DataBagValueSource;
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.AtomicConstraint;
 import com.scottlogic.deg.generator.inputs.RuleInformation;
@@ -28,16 +29,14 @@ public class CellSource {
     }
 
     public boolean isViolated(RuleInformation rule){
-        return this.source.getViolatedConstraints()
-            .stream()
-            .flatMap(c -> c.getRules().stream())
+        return FlatMappingSpliterator.flatMap(this.source.getViolatedConstraints()
+            .stream(), c -> c.getRules().stream())
             .anyMatch(r -> r.equals(rule));
     }
 
     public Set<RuleInformation> getRules(){
-        return this.source.getConstraints()
-            .stream()
-            .flatMap(c -> c.getRules().stream())
+        return FlatMappingSpliterator.flatMap(this.source.getConstraints()
+            .stream(), c -> c.getRules().stream())
             .collect(Collectors.toSet());
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/CartesianProductDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/CartesianProductDecisionTreeWalker.java
@@ -2,6 +2,7 @@ package com.scottlogic.deg.generator.walker;
 
 import com.google.inject.Inject;
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
 import com.scottlogic.deg.generator.decisiontree.DecisionNode;
@@ -84,15 +85,17 @@ public class CartesianProductDecisionTreeWalker implements DecisionTreeWalker {
                 .stream()
                 .reduce(
                     Stream.of(mergedRowSpec),
-                    (acc, decisionNode) -> acc.flatMap(aRowSpecFromCartesianProductsSoFar -> walk(decisionNode, aRowSpecFromCartesianProductsSoFar)),
+                    (acc, decisionNode) -> FlatMappingSpliterator.flatMap(
+                        acc,
+                        aRowSpecFromCartesianProductsSoFar -> walk(decisionNode, aRowSpecFromCartesianProductsSoFar)),
                     Stream::concat);
         }
 
         private Stream<RowSpec> walk(DecisionNode decision, RowSpec accumulatedSpec) {
-            return decision
+            return FlatMappingSpliterator.flatMap(decision
                     .getOptions()
-                    .stream()
-                    .flatMap(option -> walk(option, accumulatedSpec));
+                    .stream(),
+                    option -> walk(option, accumulatedSpec));
         }
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/FieldAndConstraintMapping.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/FieldAndConstraintMapping.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.constraints.atomic.*;
 
 import java.util.Collection;
@@ -31,11 +32,11 @@ public class FieldAndConstraintMapping {
     }
 
     private static int getConstraintPriority(Collection<AtomicConstraint> constraints) {
-        Set<Object> allLegalValuesForField = constraints
+        Set<Object> allLegalValuesForField = FlatMappingSpliterator.flatMap(constraints
             .stream()
             .filter(c -> (c instanceof IsInSetConstraint))
             .map(c -> (IsInSetConstraint)c)
-            .flatMap(setConstraint -> setConstraint.legalValues.stream())
+            , setConstraint -> setConstraint.legalValues.stream())
             .collect(Collectors.toSet());
 
         int setConstraintPriority = allLegalValuesForField.isEmpty()

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/SetBasedFixFieldStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/SetBasedFixFieldStrategy.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.FlatMappingSpliterator;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.IsInSetConstraint;
@@ -39,8 +40,7 @@ final class SetBasedFixFieldStrategy extends ProfileBasedFixFieldStrategy {
     }
 
     private Stream<Constraint> constraintsFromProfile(){
-        return profile.rules.stream()
-            .flatMap(rule -> rule.constraints.stream());
+        return FlatMappingSpliterator.flatMap(profile.rules.stream(), rule -> rule.constraints.stream());
     }
 
 }


### PR DESCRIPTION
#### Description
The `flatMap` implementation in the JDK will prevent any data being emitted until all data points have been calculated. In RANDOM mode the input to `flatMap` is an infinite stream (the row-limits are applied at a later stage) as such the stream never completes.

#### Changes
- Use the `flatMap` shim (workaround) as widely as possible **to save falling into this trap in the future**
- Some uses of `flatMap` have not been changed as they would require further changes to allow their use

#### Additional notes
No expected change in behaviour is expected

Manually tested and able to produce data with the following command (which otherwise fails on `master`)
`generate -n 100 -t random -w reductive "names-profile.json" "names-profile.csv"`
where `names-profile.json` can be created from #466 

#### Issue
Resolves #466 
Resolves #68 