### PR TITLE
Test fixes: RegexStringGenerator

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/RegexStringGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/RegexStringGeneratorTests.java
@@ -7,10 +7,9 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.*;
@@ -318,7 +317,14 @@ public class RegexStringGeneratorTests {
     private void expectFirstResult(String expectedValue) {
         StringGenerator generator = constructGenerator(true);
 
-        String actualValue = generator.generateAllValues().iterator().next();
+        String actualValue = StreamSupport
+            .stream(
+                Spliterators.spliteratorUnknownSize(
+                    generator.generateAllValues().iterator(),
+                    Spliterator.ORDERED),
+                false)
+            .limit(1)
+            .findFirst().orElse(null);
 
         Assert.assertThat(
                 actualValue,


### PR DESCRIPTION
### Description
A `RegexStringGenerator` test is failing it wasn't spotted due to #556 

### Changes
- Fixed test to ensure `hasNext()` is called before `next()` as is the contract with an `Iterator`
  - Using `Stream`s for a more indicative test of how the output would be used.
- No functional change

Raises a bigger question of why do we use/expose `Iterator`s rather than `Stream`s which would have prevented/highlighted this issue earlier.

Resolves #557