### PR TITLE
fixed `pom.xml` files so that unit and integration tests are run.

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -8,6 +8,7 @@
     <packaging>jar</packaging>
     <name>DataHelix Generator</name>
     <description>Generator for Scott Logic's DataHelix project</description>
+    <url>https://github.com/ScottLogic/datahelix</url>
 
     <parent>
         <groupId>com.scottlogic.deg</groupId>
@@ -61,6 +62,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,33 @@
     <name>DataHelix</name>
     <description>Scott Logic's DataHelix project</description>
     <inceptionYear>2018</inceptionYear>
+    <url>https://github.com/ScottLogic/datahelix</url>
+    <organization>
+        <name>Scott Logic</name>
+        <url>https://scottlogic.com/</url>
+    </organization>
+
+    <licenses></licenses>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/ScottLogic/datahelix/issues</url>
+    </issueManagement>
+
+    <scm>
+        <connection>scm:git:http://github.com/ScottLogic/datahelix.git</connection>
+        <developerConnection>scm:git:https://github.com/ScottLogic/datahelix.git</developerConnection>
+        <url>https://github.com/ScottLogic/datahelix</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <email></email>
+            <name>Scott Logic</name>
+            <url>http://www.scottlogic.com/</url>
+            <id>scottlogic</id>
+        </developer>
+    </developers>
 
     <modules>
         <module>schemas</module>
@@ -102,7 +129,60 @@
                     </reportSet>
                 </reportSets>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jdepend-maven-plugin</artifactId>
+                <version>2.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changes-plugin</artifactId>
+                <version>2.12.1</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>github-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+
         </plugins>
     </reporting>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.2.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -6,6 +6,9 @@
 
     <artifactId>schemas</artifactId>
     <packaging>jar</packaging>
+    <name>DataHelix Schema Library</name>
+    <description>Schema Library for Scott Logic's DataHelix project</description>
+    <url>https://github.com/ScottLogic/datahelix</url>
 
     <parent>
         <groupId>com.scottlogic.deg</groupId>
@@ -85,15 +88,6 @@
     <build>
         <finalName>${project.artifactId}</finalName>
         <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
 </project>


### PR DESCRIPTION
Fix `pom.xml` files to run all tests.

junit 4 and junit 5 tests are now run when `mvn test` is executed.

resolves #536 