### PR TITLE
Fixes for reductive iteration visualiser

### DIFF
--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -20,6 +20,8 @@ Options are optional and case-insensitive
     * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details
 * `--trace-constraints`
    * When generating data emit a `<output path>.trace.json` file which will contain details of which rules and constraints caused the generator to emit each data point.
+* `--visualise-reductions`
+   * Debug mode for the generator. Turn on per-reduction visualisation of the profile decision tree. Will create a directory named `reductive-walker` under the output path for the files.
 
 By default the generator will report how much data has been generated over time, the other options are below:
 * `--verbose`

--- a/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
@@ -91,6 +91,11 @@ public class GenerateCommandLine extends CommandLineBase {
         description = "Turns ON system out monitoring")
     private Boolean verbose = false;
 
+    @CommandLine.Option(
+        names = {"--visualise-reductions"},
+        description = "Visualise each tree reduction")
+    private Boolean visualiseReductions = false;
+
     @Override
     public boolean shouldDoPartitioning() {
         return !this.dontPartitionTrees;
@@ -162,6 +167,11 @@ public class GenerateCommandLine extends CommandLineBase {
     @Override
     public boolean getValidateProfile() {
         return this.validateProfile;
+    }
+
+    @Override
+    public boolean visualiseReductions() {
+        return visualiseReductions;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -57,10 +57,10 @@ public class BaseModule extends AbstractModule {
         bind(ProfileValidator.class).toProvider(ProfileValidatorProvider.class);
         bind(GenerationEngine.class).toProvider(GenerationEngineProvider.class);
         bind(ReductiveDataGeneratorMonitor.class).toProvider(MonitorProvider.class).in(Singleton.class);
+        bind(IterationVisualiser.class).toProvider(IterationVisualiserProvider.class);
 
         // Bind known implementations - no user input required
         bind(DataGeneratorMonitor.class).to(ReductiveDataGeneratorMonitor.class);
-        bind(IterationVisualiser.class).to(NoOpIterationVisualiser.class);
         bind(FixFieldStrategy.class).to(HierarchicalDependencyFixFieldStrategy.class);
         bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);
         bind(DecisionTreeFactory.class).to(ProfileDecisionTreeFactory.class);

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/IterationVisualiserProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/IterationVisualiserProvider.java
@@ -1,0 +1,34 @@
+package com.scottlogic.deg.generator.Guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.walker.reductive.IterationVisualiser;
+import com.scottlogic.deg.generator.walker.reductive.NoOpIterationVisualiser;
+import com.scottlogic.deg.generator.walker.reductive.ReductiveIterationVisualiser;
+
+
+public class IterationVisualiserProvider implements Provider<IterationVisualiser> {
+    private final GenerationConfigSource source;
+    private final NoOpIterationVisualiser noOpIterationVisualiser;
+    private final ReductiveIterationVisualiser reductiveIterationVisualiser;
+
+    @Inject
+    public IterationVisualiserProvider(
+        GenerationConfigSource source,
+        NoOpIterationVisualiser noOpIterationVisualiser,
+        ReductiveIterationVisualiser reductiveIterationVisualiser) {
+        this.source = source;
+        this.noOpIterationVisualiser = noOpIterationVisualiser;
+        this.reductiveIterationVisualiser = reductiveIterationVisualiser;
+    }
+
+    @Override
+    public IterationVisualiser get() {
+        if (source.visualiseReductions()){
+            return reductiveIterationVisualiser;
+        }
+
+        return noOpIterationVisualiser;
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
@@ -35,4 +35,5 @@ public interface GenerationConfigSource {
     boolean isEnableTracing();
     File getProfileFile();
     boolean shouldViolate();
+    boolean visualiseReductions();
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveIterationVisualiser.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveIterationVisualiser.java
@@ -24,9 +24,16 @@ public class ReductiveIterationVisualiser implements IterationVisualiser {
 
     @Inject
     public ReductiveIterationVisualiser(@Named("outputPath") Path outputPath) {
-        Path directoryPath = outputPath.getParent() == null
-            ? Paths.get(System.getProperty("user.dir"))
-            : outputPath.getParent();
+        boolean outputPathIsADirectory = outputPath != null && outputPath.toFile().isDirectory();
+
+        Path directoryPath;
+        if (outputPathIsADirectory) {
+            directoryPath = outputPath;
+        } else {
+            directoryPath = outputPath == null || outputPath.getParent() == null
+                ? Paths.get(System.getProperty("user.dir"))
+                : outputPath.getParent();
+        }
 
         this.visualiseDirectoryPath = directoryPath.resolve("reductive-walker");
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigSource.java
@@ -84,4 +84,9 @@ public class CucumberGenerationConfigSource implements GenerationConfigSource {
     public boolean shouldViolate() {
         return state.shouldViolate;
     }
+
+    @Override
+    public boolean visualiseReductions() {
+        return false;
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
@@ -94,4 +94,9 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     public boolean shouldViolate() {
         return false;
     }
+
+    @Override
+    public boolean visualiseReductions() {
+        return false;
+    }
 }


### PR DESCRIPTION
### Description
1. The reductive iteration visualiser didn't work with violations and normal generation in equal measure
1. The reductive iteration visualiser couldn't be enabled without recompiling the code

### Changes
1. Reductive iteration visualiser now works when violating (directory output path) and when not-violating (file output path)
1. Reductive iteration visualiser can be enabled via the command line (--visualise-reductions)

### Additional notes
- [x] Manual testing undertaken
- [x] Documentation updated
- @harryBedfordSL / @EllieHield the mind-map for UX should be updated with this switch - #548 

Resolves #560 