### PR TITLE
569 Fix Trace Constraints Filename Error 

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/dataset_writers/SourceTracingDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/dataset_writers/SourceTracingDataSetWriter.java
@@ -28,7 +28,7 @@ public class SourceTracingDataSetWriter implements DataSetWriter<SourceTracingDa
 
     @Override
     public JsonArrayOutputWriter openWriter(Path directory, String fileName, ProfileFields profileFields) throws IOException {
-        return new JsonArrayOutputWriter(new PrintWriter(new FileOutputStream(fileName, false)));
+        return new JsonArrayOutputWriter(new PrintWriter(new FileOutputStream(directory.resolve(fileName).toString(), false)));
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
@@ -34,9 +34,10 @@ public class FileOutputTarget implements OutputTarget{
             directoryPath = Paths.get(System.getProperty("user.dir"));
         }
 
-        String fileNameWithoutExtension = this.filePath.getFileName().toString();
+        String fileNameWithoutExtension = this.filePath.getFileName().toString().replaceAll("\\.[^.]+$", "");
+        String fileName = this.dataSetWriter.getFileName(fileNameWithoutExtension);
 
-        try (Closeable writer = this.dataSetWriter.openWriter(directoryPath, fileNameWithoutExtension, profileFields)) {
+        try (Closeable writer = this.dataSetWriter.openWriter(directoryPath, fileName, profileFields)) {
             generatedObjects.forEach(row -> {
                 try {
                     this.dataSetWriter.writeRow(writer, row);


### PR DESCRIPTION
### Description
 - Fixed `--trace-constraints` option

### Changes
 - added regex replace all to trim file extensions from output file names before generating -trace.json file name 
 - added directory resolution to ensure file is outputted on file path specified not working directory

### Issue
Resolves #569 