### PR TITLE
548 documentation correction and CL clarifying 

### DIFF
--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -8,9 +8,9 @@ Options are optional and case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows
    * Mandatory in `RANDOM` mode
-* `-c <combinationType>` or `--c <combinationTye>`
+* `-c <combinationType>`, `--c <combinationType>` or `--combination-strategy <combinationType>`
    * When producing data combine each data point using the `<combinationType>` strategy. Options are: `PINNING` (default), `EXHAUSTIVE`, `MINIMAL`, see [Combination strategies](../../generator/docs/CombinationStrategies.md) for more details.
-* `-w <walker>` or `--w <walker>`
+* `-w <walker>`, `--w <walker>` or `--walker-type <walker>`
    * Use `<walker>` strategy for producing data. Options are: `CARTESIAN_PRODUCT`, `ROUTED`, `REDUCTIVE` (default), see [Tree walker types](../../generator/docs/TreeWalkerTypes.md) for more details.
 * `--no-partition`
    * Prevent rules from being partitioned during generation. Partitioning allows for a (unproven) performance improvement when processing larger profiles.

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -19,7 +19,7 @@ Options are optional and case-insensitive
 * `-v`, `--v` or `--validate-profile`
     * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details
 * `--trace-constraints`
-   * When generating data emit a `<output path>.trace.json` file which will contain details of which rules and constraints caused the generator to emit each data point.
+   * When generating data emit a `<output path>-trace.json` file which will contain details of which rules and constraints caused the generator to emit each data point. See [Tracing Output](../../generator/docs/TracingOutput.md) for more details.
 * `--visualise-reductions`
    * Debug mode for the generator. Turn on per-reduction visualisation of the profile decision tree. Will create a directory named `reductive-walker` under the output path for the files.
 

--- a/generator/docs/TracingOutput.md
+++ b/generator/docs/TracingOutput.md
@@ -9,7 +9,6 @@ Enabling this facility when generating data will:
 * Generate (progressively)*** a JSON formatted file named _&lt;output-file-name&gt;_-trace.json with the meta information (see structure below)
 
 ## Notes on output
-__\*\*__ Note: this facility is not currently configurable, it requires a rebuild with the `SourceTracingDataSetWriter` used with the `MultiDataSetWriter` in  `Generate.java`.   
 __\*\*\*__ This JSON file is generated progressively, as such you can read the file with a text-editor during generation but it will not be valid JSON until the generator has exited. In the above example the final `]` will only be emitted after rows have been emitted.
 
 ## JSON structure

--- a/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
@@ -10,6 +10,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
+@picocli.CommandLine.Command(
+    name = "generate",
+    description = "Produces data using any options provided.",
+    mixinStandardHelpOptions = true,
+    version = "1.0")
 public class GenerateCommandLine extends CommandLineBase {
 
     @CommandLine.Parameters(index = "0", description = "The path of the profile json file.")


### PR DESCRIPTION
### Description
Clarified some contradictory documentation around generate options. Added description to generate picocli instructions.

### Changes
 - Removed outdated statement about `--trace-constraints` not being configurable
 - Corrected contradictory information about the file produced by `--trace-constraints`
 - Added full worded options to generate options where they were missing 
 - Added an encompassing description to the generate command line picocli instructions which appear when generate with no arguments is specified

Resolves #548 