### PR TITLE
577 Profile injection

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -50,7 +50,7 @@ public class BaseModule extends AbstractModule {
 
         // Bind providers - used to retrieve implementations based on user input
         bind(DecisionTreeOptimiser.class).toProvider(DecisionTreeOptimiserProvider.class);
-        bind(Profile.class).toProvider(ProfileProvider.class);
+        bind(Profile.class).toProvider(ProfileProvider.class).in(Singleton.class);
         bind(DataSetWriter.class).toProvider(DataSetWriterProvider.class);
         bind(TreePartitioner.class).toProvider(TreePartitioningProvider.class);
         bind(DecisionTreeWalker.class).toProvider(DecisionTreeWalkerProvider.class);

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -50,7 +50,6 @@ public class BaseModule extends AbstractModule {
 
         // Bind providers - used to retrieve implementations based on user input
         bind(DecisionTreeOptimiser.class).toProvider(DecisionTreeOptimiserProvider.class);
-        bind(Profile.class).toProvider(ProfileProvider.class).in(Singleton.class);
         bind(DataSetWriter.class).toProvider(DataSetWriterProvider.class);
         bind(TreePartitioner.class).toProvider(TreePartitioningProvider.class);
         bind(DecisionTreeWalker.class).toProvider(DecisionTreeWalkerProvider.class);
@@ -79,6 +78,7 @@ public class BaseModule extends AbstractModule {
         bind(Path.class).annotatedWith(Names.named("outputPath")).toProvider(OutputPathProvider.class);
 
         bind(VelocityMonitor.class).in(Singleton.class);
+        bind(ProfileProvider.class).in(Singleton.class);
     }
 
     private void bindAllCommandLineTypes() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
@@ -33,8 +33,4 @@ public class ProfileProvider implements Provider<Profile> {
             throw new RuntimeException(e);
         }
     }
-
-    public void setProfile(Profile profile) {
-        this.profile = profile;
-    }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 public class ProfileProvider implements Provider<Profile> {
     private final GenerationConfigSource configSource;
     private final ProfileReader profileReader;
+    private Profile profile;
 
     @Inject
     public ProfileProvider(GenerationConfigSource configSource, ProfileReader profileReader) {
@@ -21,10 +22,19 @@ public class ProfileProvider implements Provider<Profile> {
 
     @Override
     public Profile get() {
+        if (profile != null) {
+            return profile;
+        }
+
         try {
-            return profileReader.read(configSource.getProfileFile().toPath());
+            profile = profileReader.read(configSource.getProfileFile().toPath());
+            return profile;
         } catch (IOException | InvalidProfileException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void setProfile(Profile profile) {
+        this.profile = profile;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
@@ -11,9 +11,12 @@ import java.io.IOException;
 
 /**
  * @Deprecated as Profile should not be passed around as a dependency
+ *
+ * Note: this is not a provider, it is a cache of the profile from the profile reader
+ *
  * */
 @Deprecated
-public class ProfileProvider implements Provider<Profile> {
+public class ProfileProvider {
     private final GenerationConfigSource configSource;
     private final ProfileReader profileReader;
     private Profile profile;
@@ -24,7 +27,6 @@ public class ProfileProvider implements Provider<Profile> {
         this.profileReader = profileReader;
     }
 
-    @Override
     public Profile get() {
         if (profile != null) {
             return profile;

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/ProfileProvider.java
@@ -9,6 +9,10 @@ import com.scottlogic.deg.generator.inputs.ProfileReader;
 
 import java.io.IOException;
 
+/**
+ * @Deprecated as Profile should not be passed around as a dependency
+ * */
+@Deprecated
 public class ProfileProvider implements Provider<Profile> {
     private final GenerationConfigSource configSource;
     private final ProfileReader profileReader;

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/HierarchicalDependencyFixFieldStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/HierarchicalDependencyFixFieldStrategy.java
@@ -2,7 +2,7 @@ package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.google.inject.Inject;
 import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.Guice.ProfileProvider;
 import com.scottlogic.deg.generator.analysis.FieldDependencyAnalyser;
 import com.scottlogic.deg.generator.analysis.FieldDependencyAnalysisResult;
 
@@ -14,14 +14,14 @@ public final class HierarchicalDependencyFixFieldStrategy extends ProfileBasedFi
     private final FieldDependencyAnalyser analyser;
 
     @Inject
-    public HierarchicalDependencyFixFieldStrategy(Profile profile, FieldDependencyAnalyser analyser) {
-        super(profile);
-        this.setBasedFixFieldStrategy = new SetBasedFixFieldStrategy(profile);
+    public HierarchicalDependencyFixFieldStrategy(ProfileProvider profileProvider, FieldDependencyAnalyser analyser) {
+        super(profileProvider);
+        this.setBasedFixFieldStrategy = new SetBasedFixFieldStrategy(profileProvider);
         this.analyser = analyser;
     }
 
     Comparator<Field> getFieldOrderingStrategy() {
-        FieldDependencyAnalysisResult result = this.analyser.analyse(profile);
+        FieldDependencyAnalysisResult result = this.analyser.analyse(profileProvider.get());
         Comparator<Field> firstComparison = Comparator.comparingInt(field -> result.getDependenciesOf(field).size());
         Comparator<Field> secondComparison = Comparator.comparingInt((Field field) -> result.getDependentsOf(field).size()).reversed();
         return firstComparison.thenComparing(secondComparison)

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/ProfileBasedFixFieldStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/ProfileBasedFixFieldStrategy.java
@@ -1,7 +1,7 @@
 package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.scottlogic.deg.generator.Field;
-import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.Guice.ProfileProvider;
 import com.scottlogic.deg.generator.decisiontree.reductive.ReductiveConstraintNode;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
@@ -12,11 +12,11 @@ import java.util.stream.Collectors;
 
 public abstract class ProfileBasedFixFieldStrategy implements FixFieldStrategy {
 
-    protected final Profile profile;
+    protected final ProfileProvider profileProvider;
     private List<Field> fieldsInFixingOrder;
 
-    ProfileBasedFixFieldStrategy(Profile profile) {
-        this.profile = profile;
+    ProfileBasedFixFieldStrategy(ProfileProvider profileProvider) {
+        this.profileProvider = profileProvider;
     }
 
     @Override
@@ -29,7 +29,7 @@ public abstract class ProfileBasedFixFieldStrategy implements FixFieldStrategy {
 
     List<Field> getFieldFixingPriorityList() {
         if (fieldsInFixingOrder == null) {
-            fieldsInFixingOrder = Collections.unmodifiableList(this.profile.fields.stream()
+            fieldsInFixingOrder = Collections.unmodifiableList(this.profileProvider.get().fields.stream()
                 .sorted(getFieldOrderingStrategy())
                 .collect(Collectors.toList()));
         }

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/SetBasedFixFieldStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/SetBasedFixFieldStrategy.java
@@ -2,7 +2,7 @@ package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.FlatMappingSpliterator;
-import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.Guice.ProfileProvider;
 import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.IsInSetConstraint;
 
@@ -13,8 +13,8 @@ import java.util.stream.Stream;
 
 final class SetBasedFixFieldStrategy extends ProfileBasedFixFieldStrategy {
 
-    SetBasedFixFieldStrategy(Profile profile) {
-        super(profile);
+    SetBasedFixFieldStrategy(ProfileProvider profileProvider) {
+        super(profileProvider);
     }
 
     Comparator<Field> getFieldOrderingStrategy() {
@@ -40,7 +40,7 @@ final class SetBasedFixFieldStrategy extends ProfileBasedFixFieldStrategy {
     }
 
     private Stream<Constraint> constraintsFromProfile(){
-        return FlatMappingSpliterator.flatMap(profile.rules.stream(), rule -> rule.constraints.stream());
+        return FlatMappingSpliterator.flatMap(profileProvider.get().rules.stream(), rule -> rule.constraints.stream());
     }
 
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/Guice/ProfileProviderTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/Guice/ProfileProviderTests.java
@@ -4,6 +4,7 @@ import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.inputs.InvalidProfileException;
 import com.scottlogic.deg.generator.inputs.JsonProfileReader;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -22,9 +23,8 @@ public class ProfileProviderTests {
     @Test
     public void get_profileIsNull_profileReadIsCalled() throws IOException, InvalidProfileException {
         //Arrange
-        profileProvider.setProfile(null);
         when(configSource.getProfileFile()).thenReturn(file);
-        when(profileReader.read(configSource.getProfileFile().toPath())).thenReturn(profile);
+        when(profileReader.read(configSource.getProfileFile().toPath())).thenReturn(null);
 
         //Act
         profileProvider.get();
@@ -36,15 +36,16 @@ public class ProfileProviderTests {
     @Test
     public void get_profileIsNotNull_profileReadIsNotCalled() throws IOException, InvalidProfileException {
         //Arrange
-        profileProvider.setProfile(profile);
         when(configSource.getProfileFile()).thenReturn(file);
         when(profileReader.read(configSource.getProfileFile().toPath())).thenReturn(profile);
 
         //Act
-        profileProvider.get();
+        Profile profile1 = profileProvider.get();
+        Profile profile2 = profileProvider.get();
 
         //Assert
-        verify(profileReader, times(0)).read(configSource.getProfileFile().toPath());
+        verify(profileReader, times(1)).read(configSource.getProfileFile().toPath());
+        Assert.assertSame(profile1, profile2);
     }
 
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/Guice/ProfileProviderTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/Guice/ProfileProviderTests.java
@@ -1,0 +1,50 @@
+package com.scottlogic.deg.generator.Guice;
+
+import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+import com.scottlogic.deg.generator.inputs.JsonProfileReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+public class ProfileProviderTests {
+
+    private GenerationConfigSource configSource = mock(GenerationConfigSource.class);
+    private JsonProfileReader profileReader = mock(JsonProfileReader.class);
+    private Profile profile = mock(Profile.class);
+    private File file = mock(File.class);
+    private ProfileProvider profileProvider = new ProfileProvider(configSource, profileReader);
+
+    @Test
+    public void get_profileIsNull_profileReadIsCalled() throws IOException, InvalidProfileException {
+        //Arrange
+        profileProvider.setProfile(null);
+        when(configSource.getProfileFile()).thenReturn(file);
+        when(profileReader.read(configSource.getProfileFile().toPath())).thenReturn(profile);
+
+        //Act
+        profileProvider.get();
+
+        //Assert
+        verify(profileReader, times(1)).read(configSource.getProfileFile().toPath());
+    }
+
+    @Test
+    public void get_profileIsNotNull_profileReadIsNotCalled() throws IOException, InvalidProfileException {
+        //Arrange
+        profileProvider.setProfile(profile);
+        when(configSource.getProfileFile()).thenReturn(file);
+        when(profileReader.read(configSource.getProfileFile().toPath())).thenReturn(profile);
+
+        //Act
+        profileProvider.get();
+
+        //Assert
+        verify(profileReader, times(0)).read(configSource.getProfileFile().toPath());
+    }
+
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/TestHierarchicalDependencyFixFieldStrategy.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/walker/reductive/field_selection_strategy/TestHierarchicalDependencyFixFieldStrategy.java
@@ -2,6 +2,7 @@ package com.scottlogic.deg.generator.walker.reductive.field_selection_strategy;
 
 import com.scottlogic.deg.generator.ConstraintBuilder;
 import com.scottlogic.deg.generator.Field;
+import com.scottlogic.deg.generator.Guice.ProfileProvider;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.Rule;
 import com.scottlogic.deg.generator.analysis.FieldDependencyAnalyser;
@@ -15,6 +16,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.google.inject.Provider;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestHierarchicalDependencyFixFieldStrategy {
 
@@ -208,7 +214,10 @@ public class TestHierarchicalDependencyFixFieldStrategy {
     private List<Field> getPriorities(List<Field> fields, List<Constraint> constraints) {
         List<Rule> rules = Collections.singletonList(new Rule(rule("Test rule"), constraints));
         Profile profile = new Profile(fields, rules);
-        HierarchicalDependencyFixFieldStrategy strategy = new HierarchicalDependencyFixFieldStrategy(profile, new FieldDependencyAnalyser());
+        ProfileProvider provider = mock(ProfileProvider.class);
+        when(provider.get()).thenReturn(profile);
+
+        HierarchicalDependencyFixFieldStrategy strategy = new HierarchicalDependencyFixFieldStrategy(provider, new FieldDependencyAnalyser());
         return strategy.getFieldFixingPriorityList();
     }
 


### PR DESCRIPTION
### Description
Before this change the `Profile` itself was being injected into classes where it was used. This caused a Guice provisioning error at run time whenever the `profile` was invalid. Now, the `profileProvider` is injected into the classes where a profile needed. This ensures Guice can always provision the dependency, and an exception is only thrown due to an error in reading the profile.

### Changes
- `profileProvider` now injected instead of `Profile` where needed
- `profileProvider` updated to store the profile itself, meaning that reading the profile only occurs once
- Unit tests added for `profileProvider` functionality
- Fixed `TestHierarchicalDependencyFixFieldStrategy.java` to use `profileProver` instead of `profile` when newing up the strategy

### Additional notes
Passing the profile throw method arguments was attempted. However, this quickly became convoluted, where certain methods had to have a profile in its argument to satisfy a contract much deeper within the code. This concept was therefore not taken forward.

### Issue
Related to #577 