### PR TITLE
576 consistency refactor

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
@@ -13,8 +13,10 @@ import java.util.Optional;
 @picocli.CommandLine.Command(
     name = "generate",
     description = "Produces data using any options provided.",
-    mixinStandardHelpOptions = true,
-    version = "1.0")
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    abbreviateSynopsis = true)
 public class GenerateCommandLine extends CommandLineBase {
 
     @CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
@@ -100,6 +102,12 @@ public class GenerateCommandLine extends CommandLineBase {
         names = {"--visualise-reductions"},
         description = "Visualise each tree reduction")
     private Boolean visualiseReductions = false;
+
+    @CommandLine.Option(
+        names = "--help",
+        usageHelp = true,
+        description = "Display these available command line options")
+    boolean help;
 
     @Override
     public boolean shouldDoPartitioning() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
@@ -31,8 +31,8 @@ public class Visualise implements Runnable {
     @picocli.CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
     private File sourceFile;
 
-    @picocli.CommandLine.Parameters(index = "1", description = "The directory into which generated data should be saved.")
-    private Path outputDir;
+    @picocli.CommandLine.Parameters(index = "1", description = "The path to write the visualise file to.")
+    private File outputPath;
 
     @picocli.CommandLine.Option(
         names = {"-t", "--title"},
@@ -82,7 +82,7 @@ public class Visualise implements Runnable {
             profile.fields,
             new RowSpecMerger(fieldSpecMerger),
             new ConstraintReducer(new FieldSpecFactory(), fieldSpecMerger));
-        
+
         DecisionTree validatedTree = treeValidator.markContradictions(mergedTree);
 
         final String title = shouldHideTitle
@@ -96,7 +96,7 @@ public class Visualise implements Runnable {
             writeTreeTo(
                 validatedTree,
                 title,
-                outputDir.resolve(profileBaseName + ".gv"));
+                outputPath.toPath());
         } catch (IOException e) {
             System.err.println(e.getMessage());
             e.printStackTrace();

--- a/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
@@ -32,7 +32,7 @@ public class Visualise implements Runnable {
     private File profileFile;
 
     @CommandLine.Parameters(index = "1", description = "The path of the output visualise file.")
-    private File outputFile;
+    private Path outputPath;
 
     @CommandLine.Option(
         names = {"-t", "--title"},
@@ -102,7 +102,7 @@ public class Visualise implements Runnable {
             writeTreeTo(
                 validatedTree,
                 title,
-                outputFile.toPath());
+                outputPath);
         } catch (IOException e) {
             System.err.println(e.getMessage());
             e.printStackTrace();

--- a/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Visualise.java
@@ -1,7 +1,6 @@
 package com.scottlogic.deg.generator;
 
 import com.scottlogic.deg.generator.decisiontree.*;
-import com.scottlogic.deg.generator.decisiontree.tree_partitioning.NoopTreePartitioner;
 import com.scottlogic.deg.generator.decisiontree.visualisation.DecisionTreeVisualisationWriter;
 import com.scottlogic.deg.generator.inputs.JsonProfileReader;
 import com.scottlogic.deg.generator.inputs.validation.NoopProfileValidator;
@@ -10,6 +9,7 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecMerger;
 import com.scottlogic.deg.generator.fieldspecs.RowSpecMerger;
 import com.scottlogic.deg.generator.validators.StaticContradictionDecisionTreeValidator;
+import picocli.CommandLine;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -17,44 +17,50 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@picocli.CommandLine.Command(
+@CommandLine.Command(
     name = "visualise",
     description = "Produces a decision tree in DOT format for the specified profile.",
-    mixinStandardHelpOptions = true,
-    version = "1.0")
+    descriptionHeading = "%nDescription:%n",
+    parameterListHeading = "%nParameters:%n",
+    optionListHeading = "%nOptions:%n",
+    abbreviateSynopsis = true)
 public class Visualise implements Runnable {
-    @picocli.CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
-    private File sourceFile;
+    @CommandLine.Parameters(index = "0", description = "The path of the profile json file.")
+    private File profileFile;
 
-    @picocli.CommandLine.Parameters(index = "1", description = "The path to write the visualise file to.")
-    private File outputPath;
+    @CommandLine.Parameters(index = "1", description = "The path of the output visualise file.")
+    private File outputFile;
 
-    @picocli.CommandLine.Option(
+    @CommandLine.Option(
         names = {"-t", "--title"},
         description = "The title to place at the top of the file")
     private String titleOverride;
 
-    @picocli.CommandLine.Option(
+    @CommandLine.Option(
         names = {"--no-title"},
         description = "Hides the title from the output")
     private boolean shouldHideTitle;
 
-    @picocli.CommandLine.Option(
+    @CommandLine.Option(
             names = {"--no-optimise"},
             description = "Prevents tree optimisation",
             hidden = true)
     private boolean dontOptimise;
 
-    @picocli.CommandLine.Option(
+    @CommandLine.Option(
         names = {"--no-simplify"},
         description = "Prevents tree simplification",
         hidden = true)
     private boolean dontSimplify;
+
+    @CommandLine.Option(
+        names = "--help",
+        usageHelp = true,
+        description = "Display these available command line options")
+    boolean help;
 
     @Override
     public void run() {
@@ -62,7 +68,7 @@ public class Visualise implements Runnable {
         final Profile profile;
 
         try {
-            profile = new JsonProfileReader(new NoopProfileValidator()).read(sourceFile.toPath());
+            profile = new JsonProfileReader(new NoopProfileValidator()).read(profileFile.toPath());
         } catch (Exception e) {
             System.err.println("Failed to read file!");
             e.printStackTrace();
@@ -73,7 +79,7 @@ public class Visualise implements Runnable {
         final DecisionTree mergedTree = decisionTreeCollection.getMergedTree();
         final FieldSpecMerger fieldSpecMerger = new FieldSpecMerger();
 
-        final String profileBaseName = sourceFile.getName().replaceFirst("\\.[^.]+$", "");
+        final String profileBaseName = profileFile.getName().replaceFirst("\\.[^.]+$", "");
         final DecisionTreeOptimiser treeOptimiser = dontOptimise
                 ? new NoopDecisionTreeOptimiser()
                 : new MostProlificConstraintOptimiser();
@@ -96,7 +102,7 @@ public class Visualise implements Runnable {
             writeTreeTo(
                 validatedTree,
                 title,
-                outputPath.toPath());
+                outputFile.toPath());
         } catch (IOException e) {
             System.err.println(e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
### Description
Updating the visualise and generate command line options to display in a consistent format. 

### Changes
- changed visualise to require a file path not a directory path to be consistent with generate
- removed tree partitioning in visualise
- --version removed
- --help added as an option
- changed vocabulary to match 

### Issue
Resolves #576 