### PR TITLE
Allow offsets in datetimes (#606)

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookup.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookup.java
@@ -10,8 +10,9 @@ import com.scottlogic.deg.schemas.v3.ConstraintDTO;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.time.chrono.IsoChronology;
+import java.time.format.*;
+import java.time.temporal.ChronoField;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -261,11 +262,16 @@ public class AtomicConstraintReaderLookup {
     }
 
     private static LocalDateTime parseDate(String value) throws InvalidProfileException {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'.'SSS");
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'.'SSS"))
+            .optionalStart()
+            .appendOffset("+HH", "Z")
+            .toFormatter();
+
         try {
             return LocalDateTime.parse(value, formatter);
         } catch (DateTimeParseException dtpe){
-            throw new InvalidProfileException(String.format("Date string '%s' must be in ISO-8601 format: yyyy-MM-ddTHH:mm:ss.SSS", value));
+            throw new InvalidProfileException(String.format("Date string '%s' must be in a subset of ISO-8601 format: yyyy-MM-ddTHH:mm:ss.SSS (with optional timezone specifier)", value));
         }
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -4,8 +4,9 @@ import com.scottlogic.deg.generator.cucumber.utils.CucumberTestState;
 import cucumber.api.java.en.When;
 
 public class DateValueStep {
-
-    public static final String DATE_REGEX = "((\\d{4})-(\\d{2})-(\\d{2}T(\\d{2}:\\d{2}:\\d{2}\\.\\d{3})))$";
+    // matches ISO-8601; could be more specific.
+    // we use a plain .* at the end of the time bit because if the earlier stuff is matched then we don't really need to be stringent about the rest of it
+    public static final String DATE_REGEX = "((\\d{4})-(\\d{2})-(\\d{2}T(\\d{2}:\\d{2}:\\d{2}\\.\\d{3}.*)))$";
     private final CucumberTestState state;
 
     public DateValueStep(CucumberTestState state){


### PR DESCRIPTION
Resolves #606

### Description
- Let users specify a timezone offset in dates in profile `{ "date": ... }` objects, but only "Z" or "+HH" style (not great for e.g. Indian users admittedly, but flexible parsing in Java is painful).
- Let testers use timezone offsets in dates in cucumber tests