### PR TITLE
580 picocli consistency

### DIFF
--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -1,5 +1,5 @@
 # Generate Options
-Options are optional and case-insensitive
+Option switches are case-sensitive, arguments are case-insensitive
 
 * `--violate` 
    * Generate data which violates profile constraints.

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -2,24 +2,24 @@
 Options are optional and case-insensitive
 
 * `--violate` 
-    * generate data which violates profile constraints. Options are: `true` or `false` (default)
+   * Generate data which violates profile constraints.
 * `--dont-violate` <epistemic constraints...>
-    * choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=typeOf lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints
-* `-t <generationType>` or `--t <generationType>`
-   * Emit `<generationType>` data. Options are: `INTERESTING` (default) or `RANDOM`, `FULL_SEQUENTIAL`, see [Generation types](../../generator/docs/GenerationTypes.md) for more details
+   * Choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=typeOf lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints.
+* `-t <generationType>` or `--generation-type <generationType>`
+   * Emit `<generationType>` data. Options are: `INTERESTING` (default) or `RANDOM`, `FULL_SEQUENTIAL`, see [Generation types](../../generator/docs/GenerationTypes.md) for more details.
 * `-n <rows>` or `--max-rows <rows>`
-   * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows
-   * Mandatory in `RANDOM` mode
-* `-c <combinationType>`, `--c <combinationType>` or `--combination-strategy <combinationType>`
+   * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
+   * Mandatory in `RANDOM` mode.
+* `-c <combinationType>` or `--combination-strategy <combinationType>`
    * When producing data combine each data point using the `<combinationType>` strategy. Options are: `PINNING` (default), `EXHAUSTIVE`, `MINIMAL`, see [Combination strategies](../../generator/docs/CombinationStrategies.md) for more details.
-* `-w <walker>`, `--w <walker>` or `--walker-type <walker>`
+* `-w <walker>` or `--walker-type <walker>`
    * Use `<walker>` strategy for producing data. Options are: `CARTESIAN_PRODUCT`, `ROUTED`, `REDUCTIVE` (default), see [Tree walker types](../../generator/docs/TreeWalkerTypes.md) for more details.
 * `--no-partition`
    * Prevent rules from being partitioned during generation. Partitioning allows for a (unproven) performance improvement when processing larger profiles.
 * `--no-optimise`
    * Prevent profiles from being optimised during generation. Optimisation enables the generator to process profiles more efficiently, but adds more compute in other areas. See [Decision tree optimiser](../../generator/docs/OptimisationProcess.md) for more details.
-* `-v`, `--v` or `--validate-profile`
-    * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details
+* `--validate-profile`
+   * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details.
 * `--trace-constraints`
    * When generating data emit a `<output path>-trace.json` file which will contain details of which rules and constraints caused the generator to emit each data point. See [Tracing Output](../../generator/docs/TracingOutput.md) for more details.
 * `--visualise-reductions`

--- a/docs/Options/VisualiseOptions.md
+++ b/docs/Options/VisualiseOptions.md
@@ -1,5 +1,5 @@
 # Visualise Options
-Options are optional and case-insensitive
+Option switches are case-sensitive, arguments are case-insensitive
 
 * `-t <title>` or `--title <title>`
    * Include the given `<title>` in the visualisation. If not supplied, the description of in profile will be used, or the filename of the profile.

--- a/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
@@ -25,7 +25,7 @@ public class GenerateCommandLine extends CommandLineBase {
     @CommandLine.Parameters(index = "1", description = "The path to write the generated data file to.")
     private Path outputPath;
 
-    @CommandLine.Option(names = {"-t", "--t", "--generation-type"},
+    @CommandLine.Option(names = {"-t", "--generation-type"},
         description = "Determines the type of data generation performed (" +
             GenerationConfig.Constants.GenerationTypes.FULL_SEQUENTIAL +
             ", " + GenerationConfig.Constants.GenerationTypes.INTERESTING +
@@ -33,7 +33,7 @@ public class GenerateCommandLine extends CommandLineBase {
         defaultValue = GenerationConfig.Constants.GenerationTypes.DEFAULT)
     private GenerationConfig.DataGenerationType generationType;
 
-    @CommandLine.Option(names = {"-c", "--c", "--combination-strategy"},
+    @CommandLine.Option(names = {"-c", "--combination-strategy"},
         description = "Determines the type of combination strategy used (" +
             GenerationConfig.Constants.CombinationStrategies.PINNING + ", " +
             GenerationConfig.Constants.CombinationStrategies.EXHAUSTIVE + ", " +
@@ -54,19 +54,19 @@ public class GenerateCommandLine extends CommandLineBase {
         hidden = true)
     private boolean dontPartitionTrees;
 
-    @CommandLine.Option(names = {"-w", "--w", "--walker-type"},
+    @CommandLine.Option(names = {"-w", "--walker-type"},
         description = "Determines the tree walker that should be used.",
         defaultValue = GenerationConfig.Constants.WalkerTypes.DEFAULT,
         hidden = true)
     private GenerationConfig.TreeWalkerType walkerType;
 
     @CommandLine.Option(
-        names = {"-n", "--n", "--max-rows"},
+        names = {"-n", "--max-rows"},
         description = "Defines the maximum number of rows that should be generated")
     private Long maxRows;
 
     @CommandLine.Option(
-        names = {"-v", "--v", "--validate-profile"},
+        names = {"--validate-profile"},
         description = "Defines whether to validate the profile (" +
             true+ ", " +
             false + ").")


### PR DESCRIPTION
### Description
Made picocli commands more consistent and updated options documentation.

### Changes
 - Removed single letter double dash option switches (i.e. only allow -t not --t)
 - Updated documentation to reflect this and make consistent throughout

### Issue
Resolves #580 