### PR TITLE
issue #566 - Add check for overwriting output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 *.orig
 classes/
 profiler/
+target/
 
 # Eclipse files
 **/*.cache-main

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -2,7 +2,7 @@
 Option switches are case-sensitive, arguments are case-insensitive
 
 * `--overwrite`
-    * Overwrite existing output files. Options are: `true` or `false` (default)
+    * Overwrite existing output files.
 * `--violate`
    * Generate data which violates profile constraints.
 * `--dont-violate` <epistemic constraints...>

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -1,7 +1,9 @@
 # Generate Options
 Option switches are case-sensitive, arguments are case-insensitive
 
-* `--violate` 
+* `--overwrite`
+    * Overwrite existing output files. Options are: `true` or `false` (default)
+* `--violate`
    * Generate data which violates profile constraints.
 * `--dont-violate` <epistemic constraints...>
    * Choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=typeOf lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints.

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -180,6 +180,23 @@
                     </configuration>
                 </plugin>
 
+                <!-- Generate UML diagrams in javadoc using doclet: mvn javadoc:javadoc -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
+                        <docletArtifact>
+                            <groupId>nl.talsmasoftware</groupId>
+                            <artifactId>umldoclet</artifactId>
+                            <version>1.1.3</version>
+                        </docletArtifact>
+                        <additionalOptions>
+                            <!--<additionalOption>...</additionalOption>-->
+                        </additionalOptions>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -192,9 +192,6 @@
                             <artifactId>umldoclet</artifactId>
                             <version>1.1.3</version>
                         </docletArtifact>
-                        <additionalOptions>
-                            <!--<additionalOption>...</additionalOption>-->
-                        </additionalOptions>
                     </configuration>
                 </plugin>
             </plugins>

--- a/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/CommandLine/GenerateCommandLine.java
@@ -83,6 +83,11 @@ public class GenerateCommandLine extends CommandLineBase {
     private boolean violateProfile;
 
     @CommandLine.Option(
+        names = {"--overwrite"},
+        description = "Defines whether to overwrite existing output files")
+    private boolean overwriteOutputFiles = false;
+
+    @CommandLine.Option(
         names = {"--dont-violate"},
         arity = "0..",
         description = "Choose types of constraint should not be violated")
@@ -127,6 +132,11 @@ public class GenerateCommandLine extends CommandLineBase {
     @Override
     public boolean shouldViolate() {
         return this.violateProfile;
+    }
+
+    @Override
+    public boolean overwriteOutputFiles() {
+        return this.overwriteOutputFiles;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -40,7 +40,7 @@ public class GenerateExecute implements Runnable {
     @Override
     public void run() {
 
-        ValidationResult validationResult = validator.validateCommandLine(config);
+        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
 
         if (!validationResult.isValid()) {
             errorReporter.display(validationResult);
@@ -49,6 +49,12 @@ public class GenerateExecute implements Runnable {
 
         try {
             Profile profile = profileReader.read(configSource.getProfileFile().toPath());
+
+            validationResult = validator.validateCommandLinePostProfile(profile);
+            if (!validationResult.isValid()) {
+                errorReporter.display(validationResult);
+                return;
+            }
 
             generationEngine.generateDataSet(profile, config, fileOutputTarget);
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
@@ -36,4 +36,5 @@ public interface GenerationConfigSource {
     File getProfileFile();
     boolean shouldViolate();
     boolean visualiseReductions();
+    boolean overwriteOutputFiles();
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
-import com.scottlogic.deg.generator.outputs.TestCaseGenerationResult;
 import com.scottlogic.deg.generator.outputs.dataset_writers.DataSetWriter;
 
 import java.io.Closeable;
@@ -52,5 +51,9 @@ public class FileOutputTarget implements OutputTarget{
         return new FileOutputTarget(
             filePath.resolve(dataSetWriter.getFileName(filename)),
             dataSetWriter);
+    }
+
+    public Path getFilePath() {
+        return filePath;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -1,7 +1,6 @@
 package com.scottlogic.deg.generator.utils;
 
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
-import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,26 +27,17 @@ public class FileUtils {
     }
 
 
-    public boolean exists(OutputTarget target) {
-        if (!(target instanceof FileOutputTarget)) {
-            return false;
-        }
-        return Files.exists(((FileOutputTarget) target).getFilePath());
+    public boolean exists(FileOutputTarget target) {
+        return Files.exists(target.getFilePath());
     }
 
-    public boolean isDirectory(OutputTarget target) {
-        if (!(target instanceof FileOutputTarget)) {
-            return false;
-        }
-        return Files.isDirectory(((FileOutputTarget) target).getFilePath());
+    public boolean isDirectory(FileOutputTarget target) {
+        return Files.isDirectory(target.getFilePath());
     }
 
-    public boolean isDirectoryEmpty(OutputTarget target, int fileCount) {
-        if (!(target instanceof FileOutputTarget)) {
-            return false;
-        }
+    public boolean isDirectoryEmpty(FileOutputTarget target, int fileCount) {
         try {
-            Path filepath = ((FileOutputTarget) target).getFilePath();
+            Path filepath = target.getFilePath();
             if (directoryContainsManifestJsonFile(filepath) ||
                 directoryContainsFilesWithExt(filepath, "csv", fileCount)) {
                 return false;

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -2,7 +2,6 @@ package com.scottlogic.deg.generator.utils;
 
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,13 +35,9 @@ public class FileUtils {
     }
 
     public boolean isDirectoryEmpty(FileOutputTarget target, int fileCount) {
-        try {
-            Path filepath = target.getFilePath();
-            if (directoryContainsManifestJsonFile(filepath) ||
-                directoryContainsFilesWithExt(filepath, "csv", fileCount)) {
-                return false;
-            }
-        } catch (IOException e) {
+        Path filepath = target.getFilePath();
+        if (directoryContainsManifestJsonFile(filepath) ||
+            directoryContainsFilesWithExt(filepath, "csv", fileCount)) {
             return false;
         }
         return true;
@@ -52,7 +47,7 @@ public class FileUtils {
         return Files.exists(Paths.get(filePath.toString(), "manifest.json"));
     }
 
-    private boolean directoryContainsFilesWithExt(Path filePath, String ext, int fileCount) throws IOException {
+    private boolean directoryContainsFilesWithExt(Path filePath, String ext, int fileCount) {
         DecimalFormat intFormatter = FileUtils.getDecimalFormat(fileCount);
         for (int x = 1; x <= fileCount; x++) {
             if (Files.exists(Paths.get(filePath.toString(), intFormatter.format(x) + "." + ext))) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -1,5 +1,12 @@
 package com.scottlogic.deg.generator.utils;
 
+import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
+import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 
@@ -7,16 +14,61 @@ public class FileUtils {
     /**
      * Provides a decimal formatter for pre-padding numbers with just enough zeroes.
      * E.g. if there are 42 records in a dataset this will produce a formatter of "00"
+     *
      * @param numberOfDataSets Maximum number of data sets we will number
      * @return Decimal format comprised of n zeroes where n is the number of digits in the input integer.
      */
-    public static DecimalFormat getDecimalFormat(int numberOfDataSets)
-    {
-        int maxNumberOfDigits = (int)Math.ceil(Math.log10(numberOfDataSets));
+    public static DecimalFormat getDecimalFormat(int numberOfDataSets) {
+        int maxNumberOfDigits = (int) Math.ceil(Math.log10(numberOfDataSets));
 
         char[] zeroes = new char[maxNumberOfDigits];
         Arrays.fill(zeroes, '0');
 
         return new DecimalFormat(new String(zeroes));
+    }
+
+
+    public boolean exists(OutputTarget target) {
+        if (!(target instanceof FileOutputTarget)) {
+            return false;
+        }
+        return Files.exists(((FileOutputTarget) target).getFilePath());
+    }
+
+    public boolean isDirectory(OutputTarget target) {
+        if (!(target instanceof FileOutputTarget)) {
+            return false;
+        }
+        return Files.isDirectory(((FileOutputTarget) target).getFilePath());
+    }
+
+    public boolean isDirectoryEmpty(OutputTarget target, int fileCount) {
+        if (!(target instanceof FileOutputTarget)) {
+            return false;
+        }
+        try {
+            Path filepath = ((FileOutputTarget) target).getFilePath();
+            if (directoryContainsManifestJsonFile(filepath) ||
+                directoryContainsFilesWithExt(filepath, "csv", fileCount)) {
+                return false;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean directoryContainsManifestJsonFile(Path filePath) {
+        return Files.exists(Paths.get(filePath.toString(), "manifest.json"));
+    }
+
+    private boolean directoryContainsFilesWithExt(Path filePath, String ext, int fileCount) throws IOException {
+        DecimalFormat intFormatter = FileUtils.getDecimalFormat(fileCount);
+        for (int x = 1; x <= fileCount; x++) {
+            if (Files.exists(Paths.get(filePath.toString(), intFormatter.format(x) + "." + ext))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -1,15 +1,34 @@
 package com.scottlogic.deg.generator.validators;
 
+import com.google.inject.Inject;
+import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.generation.GenerationConfig;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
+import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
+import com.scottlogic.deg.generator.utils.FileUtils;
 
 import java.util.ArrayList;
 
 /**
  * Class used to determine whether the command line options are valid for generation
- * */
+ */
 public class GenerationConfigValidator {
 
-    public ValidationResult validateCommandLine(GenerationConfig config) {
+    private final OutputTarget outputTarget;
+    private final GenerationConfigSource configSource;
+    private final FileUtils fileUtils;
+
+    @Inject
+    public GenerationConfigValidator(GenerationConfigSource configSource,
+                                     OutputTarget outputTarget,
+                                     FileUtils fileUtils) {
+        this.configSource = configSource;
+        this.outputTarget = outputTarget;
+        this.fileUtils = fileUtils;
+    }
+
+    public ValidationResult validateCommandLinePreProfile(GenerationConfig config) {
         ArrayList<String> errorMessages = new ArrayList<>();
         ValidationResult validationResult = new ValidationResult(errorMessages);
 
@@ -21,4 +40,48 @@ public class GenerationConfigValidator {
 
         return validationResult;
     }
+
+    public ValidationResult validateCommandLinePostProfile(Profile profile) {
+        ArrayList<String> errorMessages = new ArrayList<>();
+        ValidationResult validationResult = new ValidationResult(errorMessages);
+
+        if (configSource.shouldViolate()) {
+            checkViolationGenerateOutputTarget(errorMessages, outputTarget, profile.rules.size());
+        } else {
+            checkGenerateOutputTarget(errorMessages, outputTarget);
+        }
+
+        return validationResult;
+    }
+
+    private void checkGenerateOutputTarget(ArrayList<String> errorMessages,
+                                           OutputTarget outputTarget) {
+        if (outputTarget instanceof FileOutputTarget) {
+            if (fileUtils.isDirectory(outputTarget)) {
+                errorMessages.add(
+                    "Invalid Output - target is a directory, please use a different output filename");
+            } else if (!configSource.overwriteOutputFiles() && fileUtils.exists(outputTarget)) {
+                errorMessages.add(
+                    "Invalid Output - file already exists, please use a different output filename or use the --overwrite option");
+            }
+        }
+    }
+
+    private void checkViolationGenerateOutputTarget(ArrayList<String> errorMessages,
+                                                    OutputTarget outputTarget, int ruleCount) {
+        if (outputTarget instanceof FileOutputTarget) {
+            if (!fileUtils.exists(outputTarget)) {
+                errorMessages.add(
+                    "Invalid Output - output directory must exist. please enter a valid directory name");
+            } else if (!fileUtils.isDirectory(outputTarget)) {
+                errorMessages
+                    .add("Invalid Output - not a directory. please enter a valid directory name");
+            } else if (!configSource.overwriteOutputFiles() && !fileUtils
+                .isDirectoryEmpty(outputTarget, ruleCount)) {
+                errorMessages.add(
+                    "Invalid Output - directory not empty. please remove any 'manfiest.json' and '[0-9].csv' files or use the --overwrite option");
+            }
+        }
+    }
+
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -57,10 +57,10 @@ public class GenerationConfigValidator {
     private void checkGenerateOutputTarget(ArrayList<String> errorMessages,
                                            OutputTarget outputTarget) {
         if (outputTarget instanceof FileOutputTarget) {
-            if (fileUtils.isDirectory(outputTarget)) {
+            if (fileUtils.isDirectory((FileOutputTarget)outputTarget)) {
                 errorMessages.add(
                     "Invalid Output - target is a directory, please use a different output filename");
-            } else if (!configSource.overwriteOutputFiles() && fileUtils.exists(outputTarget)) {
+            } else if (!configSource.overwriteOutputFiles() && fileUtils.exists((FileOutputTarget)outputTarget)) {
                 errorMessages.add(
                     "Invalid Output - file already exists, please use a different output filename or use the --overwrite option");
             }
@@ -70,14 +70,14 @@ public class GenerationConfigValidator {
     private void checkViolationGenerateOutputTarget(ArrayList<String> errorMessages,
                                                     OutputTarget outputTarget, int ruleCount) {
         if (outputTarget instanceof FileOutputTarget) {
-            if (!fileUtils.exists(outputTarget)) {
+            if (!fileUtils.exists((FileOutputTarget)outputTarget)) {
                 errorMessages.add(
                     "Invalid Output - output directory must exist. please enter a valid directory name");
-            } else if (!fileUtils.isDirectory(outputTarget)) {
+            } else if (!fileUtils.isDirectory((FileOutputTarget)outputTarget)) {
                 errorMessages
                     .add("Invalid Output - not a directory. please enter a valid directory name");
             } else if (!configSource.overwriteOutputFiles() && !fileUtils
-                .isDirectoryEmpty(outputTarget, ruleCount)) {
+                .isDirectoryEmpty((FileOutputTarget)outputTarget, ruleCount)) {
                 errorMessages.add(
                     "Invalid Output - directory not empty. please remove any 'manfiest.json' and '[0-9].csv' files or use the --overwrite option");
             }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -15,9 +15,9 @@ import java.util.ArrayList;
  */
 public class GenerationConfigValidator {
 
-    private final OutputTarget outputTarget;
-    private final GenerationConfigSource configSource;
     private final FileUtils fileUtils;
+    private final GenerationConfigSource configSource;
+    private final OutputTarget outputTarget;
 
     @Inject
     public GenerationConfigValidator(GenerationConfigSource configSource,
@@ -72,14 +72,14 @@ public class GenerationConfigValidator {
         if (outputTarget instanceof FileOutputTarget) {
             if (!fileUtils.exists((FileOutputTarget)outputTarget)) {
                 errorMessages.add(
-                    "Invalid Output - output directory must exist. please enter a valid directory name");
+                    "Invalid Output - output directory must exist, please enter a valid directory name");
             } else if (!fileUtils.isDirectory((FileOutputTarget)outputTarget)) {
                 errorMessages
-                    .add("Invalid Output - not a directory. please enter a valid directory name");
+                    .add("Invalid Output - not a directory, please enter a valid directory name");
             } else if (!configSource.overwriteOutputFiles() && !fileUtils
                 .isDirectoryEmpty((FileOutputTarget)outputTarget, ruleCount)) {
                 errorMessages.add(
-                    "Invalid Output - directory not empty. please remove any 'manfiest.json' and '[0-9].csv' files or use the --overwrite option");
+                    "Invalid Output - directory not empty, please remove any 'manfiest.json' and '[0-9].csv' files or use the --overwrite option");
             }
         }
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
@@ -33,7 +33,7 @@ public class GenerateExecuteTests {
     @Test
     public void invalidConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
-        when(validator.validateCommandLine(config)).thenReturn(validationResult);
+        when(validator.validateCommandLinePreProfile(config)).thenReturn(validationResult);
         when(validationResult.isValid()).thenReturn(false);
 
         //Act
@@ -48,7 +48,8 @@ public class GenerateExecuteTests {
     public void validConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
         File testFile = new File("TestFile");
-        when(validator.validateCommandLine(config)).thenReturn(validationResult);
+        when(validator.validateCommandLinePreProfile(config)).thenReturn(validationResult);
+        when(validator.validateCommandLinePostProfile(anyObject())).thenReturn(validationResult);
         when(configSource.getProfileFile()).thenReturn(testFile);
         when(validationResult.isValid()).thenReturn(true);
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigSource.java
@@ -7,7 +7,6 @@ import com.scottlogic.deg.schemas.v3.AtomicConstraintType;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -83,6 +82,11 @@ public class CucumberGenerationConfigSource implements GenerationConfigSource {
     @Override
     public boolean shouldViolate() {
         return state.shouldViolate;
+    }
+
+    @Override
+    public boolean overwriteOutputFiles() {
+        return false;
     }
 
     @Override

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/InMemoryOutputTarget.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/InMemoryOutputTarget.java
@@ -47,4 +47,5 @@ public class InMemoryOutputTarget implements OutputTarget {
                     .collect(Collectors.toList());
             }).collect(Collectors.toList());
     }
+
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
@@ -94,6 +94,7 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     public boolean shouldViolate() {
         return false;
     }
+
     @Override
     public boolean overwriteOutputFiles() {
         return false;

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
@@ -94,6 +94,10 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     public boolean shouldViolate() {
         return false;
     }
+    @Override
+    public boolean overwriteOutputFiles() {
+        return false;
+    }
 
     @Override
     public boolean visualiseReductions() {

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -21,8 +21,8 @@ import static org.mockito.Mockito.when;
 public class GenerationConfigValidatorTests {
 
     private Profile profile;
-    private FileUtils fileUtils=mock(FileUtils.class);
-    private FileOutputTarget outputTarget = mock(FileOutputTarget.class);
+    private FileUtils mockFileUtils = mock(FileUtils.class);
+    private FileOutputTarget mockOutputTarget = mock(FileOutputTarget.class);
     private TestGenerationConfigSource mockConfigSource = mock(TestGenerationConfigSource.class);
     private GenerationConfig config = new GenerationConfig(
         new TestGenerationConfigSource(
@@ -36,9 +36,9 @@ public class GenerationConfigValidatorTests {
     @BeforeEach
     void setup() {
         //Arrange
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
-        when(fileUtils.isDirectory(anyObject())).thenReturn(false);
-        when(fileUtils.exists(anyObject())).thenReturn(false);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(false);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
         when(mockConfigSource.shouldViolate()).thenReturn(false);
         profile = new Profile(new ArrayList<>(), new ArrayList<>());
     }
@@ -63,7 +63,7 @@ public class GenerationConfigValidatorTests {
         );
         testConfigSource.setMaxRows(1234567L);
         GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
@@ -82,7 +82,7 @@ public class GenerationConfigValidatorTests {
             GenerationConfig.CombinationStrategyType.EXHAUSTIVE
         );
         GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
@@ -103,7 +103,7 @@ public class GenerationConfigValidatorTests {
         );
         testConfigSource.setMaxRows(1234567L);
         GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
@@ -123,7 +123,7 @@ public class GenerationConfigValidatorTests {
                 GenerationConfig.CombinationStrategyType.EXHAUSTIVE
             )
         );
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
@@ -143,7 +143,7 @@ public class GenerationConfigValidatorTests {
         );
         testConfigSource.setMaxRows(1234567L);
         GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockConfigSource, outputTarget, fileUtils);
+        validator = new GenerationConfigValidator(mockConfigSource, mockOutputTarget, mockFileUtils);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
@@ -156,7 +156,7 @@ public class GenerationConfigValidatorTests {
     @Test
     public void generateOutputFileAlreadyExists() {
         //Arrange
-        when(fileUtils.exists(anyObject())).thenReturn(true);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
 
         //Act
         ValidationResult validationResult = validator
@@ -169,7 +169,7 @@ public class GenerationConfigValidatorTests {
     @Test
     public void generateOutputFileAlreadyExistsCommandLineOverwrite() {
         //Arrange
-        when(fileUtils.exists(anyObject())).thenReturn(true);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
         when(mockConfigSource.overwriteOutputFiles()).thenReturn(true);
 
         //Act
@@ -194,7 +194,7 @@ public class GenerationConfigValidatorTests {
     @Test
     public void generateOutputDirNotFile() {
         //Arrange
-        when(fileUtils.isDirectory(anyObject())).thenReturn(true);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
 
         //Act
         ValidationResult validationResult = validator
@@ -208,7 +208,7 @@ public class GenerationConfigValidatorTests {
     public void generateViolationOutputFileAlreadyExists() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(fileUtils.exists(anyObject())).thenReturn(true);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
 
         //Act
         ValidationResult validationResult = validator
@@ -222,8 +222,8 @@ public class GenerationConfigValidatorTests {
     public void generateViolationOutputFileDoesNotExist() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(fileUtils.isDirectory(anyObject())).thenReturn(false);
-        when(fileUtils.exists(anyObject())).thenReturn(false);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(false);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
 
         //Act
         ValidationResult validationResult = validator
@@ -237,9 +237,9 @@ public class GenerationConfigValidatorTests {
     public void generateViolationOutputDirNotExists() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(fileUtils.exists(anyObject())).thenReturn(false);
-        when(fileUtils.isDirectory(anyObject())).thenReturn(true);
-       when(fileUtils.isDirectoryEmpty(anyObject(), anyInt())).thenReturn(true);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
+        when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(true);
 
         //Act
         ValidationResult validationResult = validator
@@ -253,9 +253,9 @@ public class GenerationConfigValidatorTests {
     public void generateViolationOutputDirNotFile() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(fileUtils.exists(anyObject())).thenReturn(true);
-        when(fileUtils.isDirectory(anyObject())).thenReturn(true);
-        when(fileUtils.isDirectoryEmpty(anyObject(), anyInt())).thenReturn(true);
+        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
+        when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(true);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePostProfile(profile);
@@ -268,8 +268,8 @@ public class GenerationConfigValidatorTests {
     public void generateViolationOutputDirNotEmpty() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(fileUtils.isDirectory(anyObject())).thenReturn(true);
-        when(fileUtils.isDirectoryEmpty(anyObject(), anyInt())).thenReturn(false);
+        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
+        when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(false);
 
         //Act
         ValidationResult validationResult = validator.validateCommandLinePostProfile(profile);

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,13 @@
 
     <reporting>
         <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
### Description
test for overwriting an existing file

### Changes
* Update `GenerationConfigValidator` to check for whether the output file already exists and return an error if it does.
* added `--overwrite` command line option
* add tests to `GenerationConfigValidatorTests`

Resolves #566 