### PR TITLE
627 abort if unable to write manifest.json file

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -1,8 +1,8 @@
 package com.scottlogic.deg.generator.Guice;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.TypeLiteral;
 import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.scottlogic.deg.generator.CommandLine.GenerateCommandLine;
 import com.scottlogic.deg.generator.GenerationEngine;
@@ -11,19 +11,19 @@ import com.scottlogic.deg.generator.decisiontree.DecisionTreeOptimiser;
 import com.scottlogic.deg.generator.decisiontree.ProfileDecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.tree_partitioning.TreePartitioner;
 import com.scottlogic.deg.generator.generation.*;
-import com.scottlogic.deg.generator.inputs.*;
 import com.scottlogic.deg.generator.generation.databags.RowSpecDataBagSourceFactory;
-import com.scottlogic.deg.generator.inputs.JsonProfileReader;
-import com.scottlogic.deg.generator.inputs.ProfileReader;
+import com.scottlogic.deg.generator.inputs.*;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.reporters.ProfileValidationReporter;
 import com.scottlogic.deg.generator.inputs.validation.reporters.SystemOutProfileValidationReporter;
 import com.scottlogic.deg.generator.outputs.dataset_writers.DataSetWriter;
+import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
+import com.scottlogic.deg.generator.outputs.manifest.ManifestWriterImpl;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import com.scottlogic.deg.generator.violations.filters.ViolationFilter;
-import com.scottlogic.deg.generator.walker.*;
+import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
 import com.scottlogic.deg.generator.walker.reductive.IterationVisualiser;
 import com.scottlogic.deg.generator.walker.reductive.field_selection_strategy.FixFieldStrategy;
 import com.scottlogic.deg.generator.walker.reductive.field_selection_strategy.HierarchicalDependencyFixFieldStrategy;
@@ -62,6 +62,7 @@ public class BaseModule extends AbstractModule {
         bind(RowSpecDataBagSourceFactory.class).toProvider(RowSpecDataBagSourceFactoryProvider.class);
 
         // Bind known implementations - no user input required
+        bind(ManifestWriter.class).to(ManifestWriterImpl.class);
         bind(DataGeneratorMonitor.class).to(ReductiveDataGeneratorMonitor.class);
         bind(FixFieldStrategy.class).to(HierarchicalDependencyFixFieldStrategy.class);
         bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);
@@ -74,7 +75,8 @@ public class BaseModule extends AbstractModule {
         bind(ProfileViolator.class).to(IndividualRuleProfileViolator.class);
         bind(RuleViolator.class).to(IndividualConstraintRuleViolator.class);
 
-        bind(new TypeLiteral<List<ViolationFilter>>(){}).toProvider(ViolationFiltersProvider.class);
+        bind(new TypeLiteral<List<ViolationFilter>>() {
+        }).toProvider(ViolationFiltersProvider.class);
 
         bind(Path.class).annotatedWith(Names.named("outputPath")).toProvider(OutputPathProvider.class);
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -18,7 +18,7 @@ import com.scottlogic.deg.generator.inputs.validation.reporters.ProfileValidatio
 import com.scottlogic.deg.generator.inputs.validation.reporters.SystemOutProfileValidationReporter;
 import com.scottlogic.deg.generator.outputs.dataset_writers.DataSetWriter;
 import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
-import com.scottlogic.deg.generator.outputs.manifest.ManifestWriterImpl;
+import com.scottlogic.deg.generator.outputs.manifest.JsonManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
@@ -62,7 +62,7 @@ public class BaseModule extends AbstractModule {
         bind(RowSpecDataBagSourceFactory.class).toProvider(RowSpecDataBagSourceFactoryProvider.class);
 
         // Bind known implementations - no user input required
-        bind(ManifestWriter.class).to(ManifestWriterImpl.class);
+        bind(ManifestWriter.class).to(JsonManifestWriter.class);
         bind(DataGeneratorMonitor.class).to(ReductiveDataGeneratorMonitor.class);
         bind(FixFieldStrategy.class).to(HierarchicalDependencyFixFieldStrategy.class);
         bind(DataGenerator.class).to(DecisionTreeDataGenerator.class);

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/IndividualRuleProfileViolator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/IndividualRuleProfileViolator.java
@@ -7,6 +7,7 @@ import com.scottlogic.deg.generator.Rule;
 import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.violations.ViolatedProfile;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,19 +35,14 @@ public class IndividualRuleProfileViolator implements ProfileViolator {
     }
 
     @Override
-    public List<Profile> violate(Profile profile) {
+    public List<Profile> violate(Profile profile) throws IOException {
         // For each rule in the profile generate a profile with this one rule violated
         List<ViolatedProfile> violatedProfiles =
             profile.rules.stream()
                 .map(rule -> violateRuleOnProfile(profile, rule))
                 .collect(Collectors.toList());
 
-        try {
-            manifestWriter.writeManifest(violatedProfiles, outputPath);
-        }
-        catch (Exception e){
-            System.err.println("Failed to write manifest for violated profiles, continuing...");
-        }
+        manifestWriter.writeManifest(violatedProfiles, outputPath);
 
         // The following will allow the conversion to a List<Profile> from a List<ViolatedProfile>.
         return new ArrayList<>(violatedProfiles);

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/ProfileViolator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/ProfileViolator.java
@@ -2,6 +2,7 @@ package com.scottlogic.deg.generator.inputs;
 
 import com.scottlogic.deg.generator.Profile;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -15,5 +16,5 @@ public interface ProfileViolator {
      * @param profile Input profile.
      * @return List of profile objects that represent the multiple violations.
      */
-    List<Profile> violate(Profile profile);
+    List<Profile> violate(Profile profile) throws IOException;
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/JsonManifestWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/JsonManifestWriter.java
@@ -1,11 +1,11 @@
 package com.scottlogic.deg.generator.outputs.manifest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 import com.scottlogic.deg.generator.utils.FileUtils;
 import com.scottlogic.deg.generator.violations.ViolatedProfile;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-public class ManifestWriterImpl implements ManifestWriter{
+public class JsonManifestWriter implements ManifestWriter {
 
     public void writeManifest(
         List<ViolatedProfile> result,
@@ -30,7 +30,6 @@ public class ManifestWriterImpl implements ManifestWriter{
                 Collections.singleton(profile.violatedRule.ruleInformation.getDescription())))
             .collect(Collectors.toList());
 
-        System.out.println("Writing manifest.json file");
         write(
             new ManifestDTO(testCaseDtos),
             directoryPath.resolve(
@@ -45,6 +44,6 @@ public class ManifestWriterImpl implements ManifestWriter{
         Files.write(
             filepath,
             manifestAsJson.getBytes(
-                Charset.forName("UTF-8")));
+                Charsets.UTF_8));
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/JsonManifestWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/JsonManifestWriter.java
@@ -14,6 +14,10 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+/**
+ * write out a JSON manifest file during violation.
+ * This file shows which rule has been violated in which output file.
+ */
 public class JsonManifestWriter implements ManifestWriter {
 
     public void writeManifest(

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/ManifestWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/ManifestWriter.java
@@ -1,52 +1,12 @@
 package com.scottlogic.deg.generator.outputs.manifest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.scottlogic.deg.generator.outputs.manifest.ManifestDTO;
-import com.scottlogic.deg.generator.utils.FileUtils;
 import com.scottlogic.deg.generator.violations.ViolatedProfile;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.text.DecimalFormat;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
-public class ManifestWriter {
+public interface ManifestWriter {
 
-    public void writeManifest(
-        List<ViolatedProfile> result,
-        Path directoryPath) throws IOException {
-
-        AtomicInteger dataSetIndex = new AtomicInteger(1);
-        DecimalFormat intFormatter = FileUtils.getDecimalFormat(result.size());
-
-
-        List<ManifestDTO.TestCaseDTO> testCaseDtos = result
-            .stream()
-            .map(profile -> new ManifestDTO.TestCaseDTO(
-                intFormatter.format(dataSetIndex.getAndIncrement()),
-                Collections.singleton(profile.violatedRule.ruleInformation.getDescription())))
-            .collect(Collectors.toList());
-
-        System.out.println("Writing manifest");
-        write(
-            new ManifestDTO(testCaseDtos),
-            directoryPath.resolve(
-                "manifest.json"));
-    }
-
-    private void write(ManifestDTO manifest, Path filepath) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-
-        String manifestAsJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(manifest);
-
-        Files.write(
-            filepath,
-            manifestAsJson.getBytes(
-                Charset.forName("UTF-8")));
-    }
+    void writeManifest(List<ViolatedProfile> result, Path directoryPath) throws IOException;
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/ManifestWriterImpl.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/manifest/ManifestWriterImpl.java
@@ -1,0 +1,50 @@
+package com.scottlogic.deg.generator.outputs.manifest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scottlogic.deg.generator.utils.FileUtils;
+import com.scottlogic.deg.generator.violations.ViolatedProfile;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class ManifestWriterImpl implements ManifestWriter{
+
+    public void writeManifest(
+        List<ViolatedProfile> result,
+        Path directoryPath) throws IOException {
+
+        AtomicInteger dataSetIndex = new AtomicInteger(1);
+        DecimalFormat intFormatter = FileUtils.getDecimalFormat(result.size());
+
+        List<ManifestDTO.TestCaseDTO> testCaseDtos = result
+            .stream()
+            .map(profile -> new ManifestDTO.TestCaseDTO(
+                intFormatter.format(dataSetIndex.getAndIncrement()),
+                Collections.singleton(profile.violatedRule.ruleInformation.getDescription())))
+            .collect(Collectors.toList());
+
+        System.out.println("Writing manifest.json file");
+        write(
+            new ManifestDTO(testCaseDtos),
+            directoryPath.resolve(
+                "manifest.json"));
+    }
+
+    private void write(ManifestDTO manifest, Path filepath) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        String manifestAsJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(manifest);
+
+        Files.write(
+            filepath,
+            manifestAsJson.getBytes(
+                Charset.forName("UTF-8")));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberManifestWriter.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberManifestWriter.java
@@ -1,0 +1,15 @@
+package com.scottlogic.deg.generator.cucumber.utils;
+
+import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
+import com.scottlogic.deg.generator.violations.ViolatedProfile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class CucumberManifestWriter implements ManifestWriter {
+    @Override
+    public void writeManifest(List<ViolatedProfile> result, Path directoryPath) throws IOException {
+
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestModule.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestModule.java
@@ -6,6 +6,7 @@ import com.scottlogic.deg.generator.GenerationEngine;
 import com.scottlogic.deg.generator.StandardGenerationEngine;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.inputs.ProfileReader;
+import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.violations.ViolationGenerationEngine;
 
@@ -26,6 +27,7 @@ public class CucumberTestModule extends AbstractModule {
         bind(ProfileReader.class).to(CucumberProfileReader.class);
         bind(GenerationConfigSource.class).to(CucumberGenerationConfigSource.class);
         bind(OutputTarget.class).to(InMemoryOutputTarget.class).in(Singleton.class);
+        bind(ManifestWriter.class).to(CucumberManifestWriter.class);
 
         if (testState.shouldViolate) {
             bind(GenerationEngine.class).to(ViolationGenerationEngine.class);

--- a/generator/src/test/java/com/scottlogic/deg/generator/inputs/IndividualRuleProfileViolatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/inputs/IndividualRuleProfileViolatorTests.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static com.shazam.shazamcrest.MatcherAssert.assertThat;
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.*;
 
@@ -58,7 +59,7 @@ public class IndividualRuleProfileViolatorTests {
      * Violate with a profile with a single returns a single violated profile.
      */
     @Test
-    public void violate_withSingleRuleProfile_returnsSingleViolatedProfile() {
+    public void violate_withSingleRuleProfile_returnsSingleViolatedProfile() throws IOException {
         //Arrange
         Profile inputProfile = new Profile(
             Arrays.asList(fooField, barField),
@@ -93,7 +94,7 @@ public class IndividualRuleProfileViolatorTests {
      * Violate with a profile with a single returns a single violated profile.
      */
     @Test
-    public void violate_withMultipleRuleProfile_returnsMultipleViolatedProfile() {
+    public void violate_withMultipleRuleProfile_returnsMultipleViolatedProfile() throws IOException {
         //Arrange
         Profile inputProfile = new Profile(
             Arrays.asList(fooField, barField),
@@ -172,7 +173,10 @@ public class IndividualRuleProfileViolatorTests {
             .writeManifest(anyListOf(ViolatedProfile.class), eq(mockPath));
 
         //Act
-        target.violate(inputProfile);
+        IOException thrown =
+            assertThrows(IOException.class,
+                () -> target.violate(inputProfile),
+                "Expected violate() to throw IOException, but it didn't");
 
         //Assert
         verify(mockManifestWriter, times(1))

--- a/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
@@ -3,24 +3,24 @@ package com.scottlogic.deg.generator.smoke_tests;
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.StandardGenerationEngine;
+import com.scottlogic.deg.generator.cucumber.utils.CucumberManifestWriter;
 import com.scottlogic.deg.generator.decisiontree.MostProlificConstraintOptimiser;
 import com.scottlogic.deg.generator.decisiontree.ProfileDecisionTreeFactory;
 import com.scottlogic.deg.generator.decisiontree.tree_partitioning.RelatedFieldTreePartitioner;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecMerger;
 import com.scottlogic.deg.generator.fieldspecs.RowSpecMerger;
-import com.scottlogic.deg.generator.inputs.IndividualConstraintRuleViolator;
-import com.scottlogic.deg.generator.inputs.IndividualRuleProfileViolator;
-import com.scottlogic.deg.generator.inputs.JsonProfileReader;
-import com.scottlogic.deg.generator.reducer.ConstraintReducer;
 import com.scottlogic.deg.generator.generation.*;
 import com.scottlogic.deg.generator.generation.databags.StandardRowSpecDataBagSourceFactory;
+import com.scottlogic.deg.generator.inputs.IndividualConstraintRuleViolator;
+import com.scottlogic.deg.generator.inputs.IndividualRuleProfileViolator;
 import com.scottlogic.deg.generator.inputs.InvalidProfileException;
+import com.scottlogic.deg.generator.inputs.JsonProfileReader;
 import com.scottlogic.deg.generator.inputs.validation.NoopProfileValidator;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.outputs.dataset_writers.DataSetWriter;
-import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
+import com.scottlogic.deg.generator.reducer.ConstraintReducer;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import com.scottlogic.deg.generator.violations.ViolationGenerationEngine;
 import com.scottlogic.deg.generator.walker.CartesianProductDecisionTreeWalker;
@@ -103,7 +103,7 @@ class ExampleProfilesViolationTests {
                 ViolationGenerationEngine violationGenerationEngine =
                     new ViolationGenerationEngine(
                         new IndividualRuleProfileViolator(
-                            new ManifestWriter(),
+                            new CucumberManifestWriter(),
                             null,
                             new IndividualConstraintRuleViolator(new ArrayList<>())),
                         engine);


### PR DESCRIPTION
### Description
Update code to throw IOException if it is unable to write the `manifest.json` file.
refactor `ManifestWriter` into an interface and use Guice to inject it into code and tests.

Resolves #627 