### PR TITLE
567 remove provisioning errors

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -19,7 +19,7 @@ public class GenerateExecute implements Runnable {
     private final GenerationConfigSource configSource;
     private final ConfigValidator validator;
     private final GenerationEngine generationEngine;
-    private final OutputTarget fileOutputTarget;
+    private final OutputTarget outputTarget;
     private final ProfileReader profileReader;
 
     @Inject

--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -27,14 +27,14 @@ public class GenerateExecute implements Runnable {
                            ProfileReader profileReader,
                            GenerationEngine generationEngine,
                            GenerationConfigSource configSource,
-                           OutputTarget fileOutputTarget,
+                           OutputTarget outputTarget,
                            ConfigValidator validator,
                            ErrorReporter errorReporter) {
         this.config = config;
         this.profileReader = profileReader;
         this.generationEngine = generationEngine;
         this.configSource = configSource;
-        this.fileOutputTarget = fileOutputTarget;
+        this.outputTarget = outputTarget;
         this.validator = validator;
         this.errorReporter = errorReporter;
     }
@@ -42,7 +42,7 @@ public class GenerateExecute implements Runnable {
     @Override
     public void run() {
 
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config, configSource);
 
         if (!validationResult.isValid()) {
             errorReporter.display(validationResult);
@@ -52,13 +52,13 @@ public class GenerateExecute implements Runnable {
         try {
             Profile profile = profileReader.read(configSource.getProfileFile().toPath());
 
-            validationResult = validator.validateCommandLinePostProfile(profile);
+            validationResult = validator.validateCommandLinePostProfile(profile, configSource, outputTarget);
             if (!validationResult.isValid()) {
                 errorReporter.display(validationResult);
                 return;
             }
 
-            generationEngine.generateDataSet(profile, config, fileOutputTarget);
+            generationEngine.generateDataSet(profile, config, outputTarget);
 
         } catch (IOException | InvalidProfileException e) {
             e.printStackTrace();

--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -42,7 +42,7 @@ public class GenerateExecute implements Runnable {
     @Override
     public void run() {
 
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         if (!validationResult.isValid()) {
             errorReporter.display(validationResult);

--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -2,6 +2,7 @@ package com.scottlogic.deg.generator;
 
 import com.google.inject.Inject;
 import com.scottlogic.deg.generator.generation.GenerationConfig;
+import com.scottlogic.deg.generator.validators.ConfigValidator;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.inputs.InvalidProfileException;
 import com.scottlogic.deg.generator.inputs.ProfileReader;
@@ -16,7 +17,7 @@ public class GenerateExecute implements Runnable {
     private final ErrorReporter errorReporter;
     private final GenerationConfig config;
     private final GenerationConfigSource configSource;
-    private final GenerationConfigValidator validator;
+    private final ConfigValidator validator;
     private final GenerationEngine generationEngine;
     private final OutputTarget fileOutputTarget;
     private final ProfileReader profileReader;
@@ -27,7 +28,7 @@ public class GenerateExecute implements Runnable {
                            GenerationEngine generationEngine,
                            GenerationConfigSource configSource,
                            OutputTarget fileOutputTarget,
-                           GenerationConfigValidator validator,
+                           ConfigValidator validator,
                            ErrorReporter errorReporter) {
         this.config = config;
         this.profileReader = profileReader;

--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -42,7 +42,7 @@ public class GenerateExecute implements Runnable {
     @Override
     public void run() {
 
-        ValidationResult validationResult = validator.validatePreProfile(config, configSource);
+        ValidationResult validationResult = validator.preProfileChecks(config, configSource);
 
         if (!validationResult.isValid()) {
             errorReporter.display(validationResult);
@@ -52,7 +52,7 @@ public class GenerateExecute implements Runnable {
         try {
             Profile profile = profileReader.read(configSource.getProfileFile().toPath());
 
-            validationResult = validator.validateCommandLinePostProfile(profile, configSource, outputTarget);
+            validationResult = validator.postProfileChecks(profile, configSource, outputTarget);
             if (!validationResult.isValid()) {
                 errorReporter.display(validationResult);
                 return;

--- a/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/Guice/BaseModule.java
@@ -24,6 +24,8 @@ import com.scottlogic.deg.generator.outputs.manifest.JsonManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
+import com.scottlogic.deg.generator.validators.ConfigValidator;
+import com.scottlogic.deg.generator.validators.GenerationConfigValidator;
 import com.scottlogic.deg.generator.violations.filters.ViolationFilter;
 import com.scottlogic.deg.generator.visualisation.VisualisationConfigSource;
 import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
@@ -79,6 +81,7 @@ public class BaseModule extends AbstractModule {
         bind(FieldValueSourceEvaluator.class).to(StandardFieldValueSourceEvaluator.class);
         bind(ProfileViolator.class).to(IndividualRuleProfileViolator.class);
         bind(RuleViolator.class).to(IndividualConstraintRuleViolator.class);
+        bind(ConfigValidator.class).to(GenerationConfigValidator.class);
 
         bind(new TypeLiteral<List<ViolationFilter>>() {
         }).toProvider(ViolationFiltersProvider.class);

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -2,6 +2,7 @@ package com.scottlogic.deg.generator.utils;
 
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,7 +26,14 @@ public class FileUtils {
         return new DecimalFormat(new String(zeroes));
     }
 
-    /**
+    public boolean containsInvalidChars(File file) {
+        return file.toString().matches(".*[?%*|><\"].*|^(?:[^:]*+:){2,}[^:]*+$");
+    }
+
+    public boolean isEmpty(File file) {
+        return file.length() == 0;
+    }
+     /**
      * @param target the FileOutputTarget to check the existence of.
      * @return true if the supplied FileOutputTarget exists on disk, false otherwise.
      */

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.generator.utils;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,6 +65,10 @@ public class FileUtils {
             return false;
         }
         return true;
+    }
+
+    public String probeContentType(Path path) throws IOException {
+        return Files.probeContentType(path);
     }
 
     private boolean directoryContainsManifestJsonFile(Path filePath) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -3,7 +3,6 @@ package com.scottlogic.deg.generator.utils;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,10 +64,6 @@ public class FileUtils {
             return false;
         }
         return true;
-    }
-
-    public String probeContentType(Path path) throws IOException {
-        return Files.probeContentType(path);
     }
 
     private boolean directoryContainsManifestJsonFile(Path filePath) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.utils;
 
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 
 import java.io.File;
@@ -78,5 +79,10 @@ public class FileUtils {
             }
         }
         return false;
+    }
+
+    public File getTraceFile(GenerationConfigSource configSource) {
+        String filenameWithoutExtension = configSource.getOutputPath().toString().replaceAll("\\.[^.]+$", "");
+        return Paths.get(filenameWithoutExtension + "-trace.json").toFile();
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -31,7 +31,7 @@ public class FileUtils {
         return file.toString().matches(".*[?%*|><\"].*|^(?:[^:]*+:){2,}[^:]*+$");
     }
 
-    public boolean isEmpty(File file) {
+    public boolean isFileEmpty(File file) {
         return file.length() == 0;
     }
      /**

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
@@ -1,0 +1,12 @@
+package com.scottlogic.deg.generator.validators;
+
+import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.generation.GenerationConfig;
+
+public interface ConfigValidator {
+
+    ValidationResult validateCommandLinePreProfile(GenerationConfig config);
+
+    ValidationResult validateCommandLinePostProfile(Profile profile);
+
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
@@ -2,11 +2,17 @@ package com.scottlogic.deg.generator.validators;
 
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.generation.GenerationConfig;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 
 public interface ConfigValidator {
 
-    ValidationResult validatePreProfile(GenerationConfig config);
+    ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource configSource);
 
-    ValidationResult validateCommandLinePostProfile(Profile profile);
+    ValidationResult validateCommandLinePostProfile(
+        Profile profile,
+        GenerationConfigSource configSource,
+        OutputTarget outputTarget
+    );
 
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
@@ -7,9 +7,9 @@ import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 
 public interface ConfigValidator {
 
-    ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource configSource);
+    ValidationResult preProfileChecks(GenerationConfig config, GenerationConfigSource configSource);
 
-    ValidationResult validateCommandLinePostProfile(
+    ValidationResult postProfileChecks(
         Profile profile,
         GenerationConfigSource configSource,
         OutputTarget outputTarget

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ConfigValidator.java
@@ -5,7 +5,7 @@ import com.scottlogic.deg.generator.generation.GenerationConfig;
 
 public interface ConfigValidator {
 
-    ValidationResult validateCommandLinePreProfile(GenerationConfig config);
+    ValidationResult validatePreProfile(GenerationConfig config);
 
     ValidationResult validateCommandLinePostProfile(Profile profile);
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -10,7 +10,6 @@ import com.scottlogic.deg.generator.utils.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 
 /**
@@ -81,17 +80,6 @@ public class GenerationConfigValidator implements ConfigValidator {
         }
         else if (fileUtils.isFileEmpty(profileFile)) {
             errorMessages.add("Invalid Input - Profile file has no content");
-        }
-        else {
-            try {
-                String fileType = fileUtils.probeContentType(profileFile.toPath());
-                if (!fileType.equals("application/json")) {
-                    errorMessages.add(String.format("Invalid Input - File is of type %s\nFile type application/json required", fileType));
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-                errorMessages.add("Invalid Input - Unable to determine content type of profile file");
-            }
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -28,24 +28,20 @@ public class GenerationConfigValidator implements ConfigValidator {
     }
 
     @Override
-    public ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource generationConfigSource) {
+    public ValidationResult preProfileChecks(GenerationConfig config, GenerationConfigSource generationConfigSource) {
         ArrayList<String> errorMessages = new ArrayList<>();
 
-        if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
-            && !config.getMaxRows().isPresent()) {
+        checkSwitches(config, errorMessages);
 
-            errorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
-        }
-
-        validateProfileInputFile(errorMessages, generationConfigSource.getProfileFile());
+        checkProfileInputFile(errorMessages, generationConfigSource.getProfileFile());
 
         return new ValidationResult(errorMessages);
     }
 
     @Override
-    public ValidationResult validateCommandLinePostProfile(Profile profile,
-                                                           GenerationConfigSource configSource,
-                                                           OutputTarget outputTarget) {
+    public ValidationResult postProfileChecks(Profile profile,
+                                              GenerationConfigSource configSource,
+                                              OutputTarget outputTarget) {
         ArrayList<String> errorMessages = new ArrayList<>();
         ValidationResult validationResult = new ValidationResult(errorMessages);
 
@@ -65,7 +61,15 @@ public class GenerationConfigValidator implements ConfigValidator {
         return validationResult;
     }
 
-    private void validateProfileInputFile(ArrayList<String> errorMessages, File profileFile) {
+    private void checkSwitches (GenerationConfig config, ArrayList<String> errorMessages) {
+        if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
+            && !config.getMaxRows().isPresent()) {
+
+            errorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
+        }
+    }
+
+    private void checkProfileInputFile(ArrayList<String> errorMessages, File profileFile) {
         if (fileUtils.containsInvalidChars(profileFile)) {
             errorMessages.add(String.format("Profile file path (%s) contains one or more invalid characters ? : %% \" | > < ", profileFile.toString()));
         }
@@ -75,7 +79,7 @@ public class GenerationConfigValidator implements ConfigValidator {
         else if (profileFile.isDirectory()) {
             errorMessages.add("Invalid Input - Profile file path provided is to a directory");
         }
-        else if (fileUtils.isEmpty(profileFile)) {
+        else if (fileUtils.isFileEmpty(profileFile)) {
             errorMessages.add("Invalid Input - Profile file has no content");
         }
         else {

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -8,6 +8,7 @@ import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.utils.FileUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -18,108 +19,104 @@ import java.util.ArrayList;
 public class GenerationConfigValidator implements ConfigValidator {
 
     private final FileUtils fileUtils;
-    private final GenerationConfigSource configSource;
-    private final OutputTarget outputTarget;
 
     @Inject
     public GenerationConfigValidator(FileUtils fileUtils,
                                      GenerationConfigSource configSource,
                                      OutputTarget outputTarget) {
-        this.configSource = configSource;
-        this.outputTarget = outputTarget;
         this.fileUtils = fileUtils;
     }
 
     @Override
-    public ValidationResult validatePreProfile(GenerationConfig config) {
-
+    public ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource generationConfigSource) {
         ArrayList<String> errorMessages = new ArrayList<>();
-        ValidationResult validationResult = new ValidationResult(errorMessages);
 
-        validateCommandLineOptions(config, errorMessages);
-
-        validateProfileInputFile(errorMessages);
-
-        return validationResult;
-    }
-
-    @Override
-    public ValidationResult validateCommandLinePostProfile(Profile profile) {
-        ArrayList<String> errorMessages = new ArrayList<>();
-        ValidationResult validationResult = new ValidationResult(errorMessages);
-
-        if (configSource.shouldViolate()) {
-            checkViolationGenerateOutputTarget(errorMessages, outputTarget, profile.rules.size());
-        } else {
-            checkGenerateOutputTarget(errorMessages, outputTarget);
-        }
-
-        return validationResult;
-    }
-
-    public void validateCommandLineOptions(GenerationConfig config, ArrayList<String> errorMessages) {
         if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
             && !config.getMaxRows().isPresent()) {
 
             errorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
         }
+
+        validateProfileInputFile(errorMessages, generationConfigSource.getProfileFile());
+
+        return new ValidationResult(errorMessages);
     }
 
+    @Override
+    public ValidationResult validateCommandLinePostProfile(Profile profile,
+                                                           GenerationConfigSource configSource,
+                                                           OutputTarget outputTarget) {
+        ArrayList<String> errorMessages = new ArrayList<>();
+        ValidationResult validationResult = new ValidationResult(errorMessages);
 
-    public void validateProfileInputFile(ArrayList<String> errorMessages) {
-        if (!configSource.getProfileFile().exists()){
-            errorMessages.add("Invalid Input - Profile file does not exist");
-
-            if (fileUtils.containsInvalidChars(configSource.getProfileFile())) {
-                errorMessages.add(String.format("Profile file path (%s) contains one or more invalid characters ? : %% \" | > < ", configSource.getProfileFile().toString()));
+        if (outputTarget instanceof FileOutputTarget ) {
+            if (configSource.shouldViolate()) {
+                checkViolationGenerateOutputTarget(
+                    errorMessages,
+                    configSource,
+                    (FileOutputTarget)outputTarget,
+                    profile.rules.size()
+                );
+            } else {
+                checkGenerateOutputTarget(errorMessages, configSource, (FileOutputTarget)outputTarget);
             }
         }
-        else if (configSource.getProfileFile().isDirectory()) {
+
+        return validationResult;
+    }
+
+    private void validateProfileInputFile(ArrayList<String> errorMessages, File profileFile) {
+        if (fileUtils.containsInvalidChars(profileFile)) {
+            errorMessages.add(String.format("Profile file path (%s) contains one or more invalid characters ? : %% \" | > < ", profileFile.toString()));
+        }
+        else if (!profileFile.exists()){
+            errorMessages.add("Invalid Input - Profile file does not exist");
+        }
+        else if (profileFile.isDirectory()) {
             errorMessages.add("Invalid Input - Profile file path provided is to a directory");
         }
-        else if (fileUtils.isEmpty(configSource.getProfileFile())) {
+        else if (fileUtils.isEmpty(profileFile)) {
             errorMessages.add("Invalid Input - Profile file has no content");
         }
         else {
             try {
-                String fileType = Files.probeContentType(configSource.getProfileFile().toPath());
+                String fileType = fileUtils.probeContentType(profileFile.toPath());
                 if (!fileType.equals("application/json")) {
                     errorMessages.add(String.format("Invalid Input - File is of type %s\nFile type application/json required", fileType));
                 }
             } catch (IOException e) {
                 e.printStackTrace();
+                errorMessages.add("Invalid Input - Unable to determine content type of profile file");
             }
         }
     }
 
     private void checkGenerateOutputTarget(ArrayList<String> errorMessages,
-                                           OutputTarget outputTarget) {
-        if (outputTarget instanceof FileOutputTarget) {
-            if (fileUtils.isDirectory((FileOutputTarget) outputTarget)) {
-                errorMessages.add(
-                    "Invalid Output - target is a directory, please use a different output filename");
-            } else if (!configSource.overwriteOutputFiles() && fileUtils.exists((FileOutputTarget) outputTarget)) {
-                errorMessages.add(
-                    "Invalid Output - file already exists, please use a different output filename or use the --overwrite option");
-            }
+                                           GenerationConfigSource configSource,
+                                           FileOutputTarget outputTarget) {
+        if (fileUtils.isDirectory(outputTarget)) {
+            errorMessages.add(
+                "Invalid Output - target is a directory, please use a different output filename");
+        } else if (!configSource.overwriteOutputFiles() && fileUtils.exists(outputTarget)) {
+            errorMessages.add(
+                "Invalid Output - file already exists, please use a different output filename or use the --overwrite option");
         }
     }
 
     private void checkViolationGenerateOutputTarget(ArrayList<String> errorMessages,
-                                                    OutputTarget outputTarget, int ruleCount) {
-        if (outputTarget instanceof FileOutputTarget) {
-            if (!fileUtils.exists((FileOutputTarget) outputTarget)) {
-                errorMessages.add(
-                    "Invalid Output - output directory must exist, please enter a valid directory name");
-            } else if (!fileUtils.isDirectory((FileOutputTarget) outputTarget)) {
-                errorMessages
-                    .add("Invalid Output - not a directory, please enter a valid directory name");
-            } else if (!configSource.overwriteOutputFiles() && !fileUtils
-                .isDirectoryEmpty((FileOutputTarget) outputTarget, ruleCount)) {
-                errorMessages.add(
+                                                    GenerationConfigSource configSource,
+                                                    FileOutputTarget outputTarget,
+                                                    int ruleCount) {
+        if (!fileUtils.exists(outputTarget)) {
+            errorMessages.add(
+                "Invalid Output - output directory must exist, please enter a valid directory name");
+        } else if (!fileUtils.isDirectory(outputTarget)) {
+            errorMessages
+                .add("Invalid Output - not a directory, please enter a valid directory name");
+        } else if (!configSource.overwriteOutputFiles() && !fileUtils
+            .isDirectoryEmpty(outputTarget, ruleCount)) {
+            errorMessages.add(
                     "Invalid Output - directory not empty, please remove any 'manifest.json' and '[0-9].csv' files or use the --overwrite option");
-            }
         }
     }
-
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -9,7 +9,6 @@ import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.utils.FileUtils;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -30,7 +29,7 @@ public class GenerationConfigValidator implements ConfigValidator {
     public ValidationResult preProfileChecks(GenerationConfig config, GenerationConfigSource generationConfigSource) {
         ArrayList<String> errorMessages = new ArrayList<>();
 
-        checkSwitches(config, errorMessages);
+        checkSwitches(config, generationConfigSource, errorMessages);
 
         checkProfileInputFile(errorMessages, generationConfigSource.getProfileFile());
 
@@ -59,11 +58,19 @@ public class GenerationConfigValidator implements ConfigValidator {
         return new ValidationResult(errorMessages);
     }
 
-    private void checkSwitches (GenerationConfig config, ArrayList<String> errorMessages) {
+    private void checkSwitches (GenerationConfig config,
+                                GenerationConfigSource configSource,
+                                ArrayList<String> errorMessages) {
+
         if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
             && !config.getMaxRows().isPresent()) {
 
             errorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
+        }
+        if (configSource.isEnableTracing()) {
+            if (fileUtils.getTraceFile(configSource).exists() && !configSource.overwriteOutputFiles()) {
+                errorMessages.add("Invalid Output - trace file already exists, please use a different output filename or use the --overwrite option");
+            }
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 /**
  * Class used to determine whether the command line options are valid for generation
  */
-public class GenerationConfigValidator {
+public class GenerationConfigValidator implements ConfigValidator {
 
     private final FileUtils fileUtils;
     private final GenerationConfigSource configSource;

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -57,7 +57,7 @@ public class GenerationConfigValidator implements ConfigValidator {
         return validationResult;
     }
 
-    private void validateCommandLineOptions(GenerationConfig config, ArrayList<String> errorMessages) {
+    public void validateCommandLineOptions(GenerationConfig config, ArrayList<String> errorMessages) {
         if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
             && !config.getMaxRows().isPresent()) {
 
@@ -66,7 +66,7 @@ public class GenerationConfigValidator implements ConfigValidator {
     }
 
 
-    private void validateProfileInputFile(ArrayList<String> errorMessages) {
+    public void validateProfileInputFile(ArrayList<String> errorMessages) {
         if (!configSource.getProfileFile().exists()){
             errorMessages.add("Invalid Input - Profile file does not exist");
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -42,7 +42,6 @@ public class GenerationConfigValidator implements ConfigValidator {
                                               GenerationConfigSource configSource,
                                               OutputTarget outputTarget) {
         ArrayList<String> errorMessages = new ArrayList<>();
-        ValidationResult validationResult = new ValidationResult(errorMessages);
 
         if (outputTarget instanceof FileOutputTarget ) {
             if (configSource.shouldViolate()) {
@@ -57,7 +56,7 @@ public class GenerationConfigValidator implements ConfigValidator {
             }
         }
 
-        return validationResult;
+        return new ValidationResult(errorMessages);
     }
 
     private void checkSwitches (GenerationConfig config, ArrayList<String> errorMessages) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
@@ -34,7 +34,7 @@ public class GenerateExecuteTests {
     @Test
     public void invalidConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
-        when(validator.validateCommandLinePreProfile(config)).thenReturn(mockValidationResult);
+        when(validator.validatePreProfile(config)).thenReturn(validationResult);
         when(mockValidationResult.isValid()).thenReturn(false);
 
         //Act
@@ -49,6 +49,7 @@ public class GenerateExecuteTests {
     public void validConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
         File testFile = new File("TestFile");
+        when(validator.validatePreProfile(config)).thenReturn(validationResult);
         when(configSource.getProfileFile()).thenReturn(testFile);
 
         when(profileReader.read(eq(testFile.toPath()))).thenReturn(mockProfile);

--- a/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
@@ -34,7 +34,7 @@ public class GenerateExecuteTests {
     @Test
     public void invalidConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
-        when(validator.validatePreProfile(config)).thenReturn(validationResult);
+        when(validator.validatePreProfile(config, configSource)).thenReturn(validationResult);
         when(mockValidationResult.isValid()).thenReturn(false);
 
         //Act
@@ -49,7 +49,7 @@ public class GenerateExecuteTests {
     public void validConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
         File testFile = new File("TestFile");
-        when(validator.validatePreProfile(config)).thenReturn(validationResult);
+        when(validator.validatePreProfile(config, configSource)).thenReturn(validationResult);
         when(configSource.getProfileFile()).thenReturn(testFile);
 
         when(profileReader.read(eq(testFile.toPath()))).thenReturn(mockProfile);

--- a/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
@@ -25,7 +25,7 @@ public class GenerateExecuteTests {
     private FileOutputTarget outputTarget = mock(FileOutputTarget.class);
     private GenerationConfigValidator validator = mock(GenerationConfigValidator.class);
     private ErrorReporter errorReporter = mock(ErrorReporter.class);
-    private ValidationResult mockValidationResult = mock(ValidationResult.class);
+    private ValidationResult validationResult = mock(ValidationResult.class);
     private Profile mockProfile = mock(Profile.class);
 
     private GenerateExecute excecutor = new GenerateExecute(config, profileReader, generationEngine, configSource,
@@ -35,13 +35,13 @@ public class GenerateExecuteTests {
     public void invalidConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
         when(validator.preProfileChecks(config, configSource)).thenReturn(validationResult);
-        when(mockValidationResult.isValid()).thenReturn(false);
+        when(validationResult.isValid()).thenReturn(false);
 
         //Act
         excecutor.run();
 
         //Assert
-        verify(errorReporter, times(1)).display(mockValidationResult);
+        verify(errorReporter, times(1)).display(validationResult);
         verify(profileReader, never()).read((Path) any());
     }
 
@@ -52,13 +52,9 @@ public class GenerateExecuteTests {
         when(validator.preProfileChecks(config, configSource)).thenReturn(validationResult);
         when(validator.postProfileChecks(any(Profile.class), same(configSource), same(outputTarget))).thenReturn(validationResult);
         when(configSource.getProfileFile()).thenReturn(testFile);
-
         when(profileReader.read(eq(testFile.toPath()))).thenReturn(mockProfile);
 
-        when(validator.validateCommandLinePreProfile(eq(config))).thenReturn(mockValidationResult);
-        when(validator.validateCommandLinePostProfile(eq(mockProfile))).thenReturn(mockValidationResult);
-
-        when(mockValidationResult.isValid()).thenReturn(true);
+        when(validationResult.isValid()).thenReturn(true);
 
         //Act
         excecutor.run();

--- a/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/GenerateExecuteTests.java
@@ -34,7 +34,7 @@ public class GenerateExecuteTests {
     @Test
     public void invalidConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
-        when(validator.validatePreProfile(config, configSource)).thenReturn(validationResult);
+        when(validator.preProfileChecks(config, configSource)).thenReturn(validationResult);
         when(mockValidationResult.isValid()).thenReturn(false);
 
         //Act
@@ -49,7 +49,8 @@ public class GenerateExecuteTests {
     public void validConfigCallsCorrectMethods() throws IOException, InvalidProfileException {
         //Arrange
         File testFile = new File("TestFile");
-        when(validator.validatePreProfile(config, configSource)).thenReturn(validationResult);
+        when(validator.preProfileChecks(config, configSource)).thenReturn(validationResult);
+        when(validator.postProfileChecks(any(Profile.class), same(configSource), same(outputTarget))).thenReturn(validationResult);
         when(configSource.getProfileFile()).thenReturn(testFile);
 
         when(profileReader.read(eq(testFile.toPath()))).thenReturn(mockProfile);

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
@@ -1,0 +1,21 @@
+package com.scottlogic.deg.generator.cucumber.utils;
+
+import com.scottlogic.deg.generator.Profile;
+import com.scottlogic.deg.generator.generation.GenerationConfig;
+import com.scottlogic.deg.generator.validators.ConfigValidator;
+import com.scottlogic.deg.generator.validators.ValidationResult;
+
+import java.util.ArrayList;
+
+public class CucumberGenerationConfigValidator implements ConfigValidator {
+
+    @Override
+    public ValidationResult validateCommandLinePreProfile(GenerationConfig config) {
+        return new ValidationResult(new ArrayList<>());
+    }
+
+    @Override
+    public ValidationResult validateCommandLinePostProfile(Profile profile) {
+        return new ValidationResult(new ArrayList<>());
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
@@ -2,6 +2,8 @@ package com.scottlogic.deg.generator.cucumber.utils;
 
 import com.scottlogic.deg.generator.Profile;
 import com.scottlogic.deg.generator.generation.GenerationConfig;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.validators.ConfigValidator;
 import com.scottlogic.deg.generator.validators.ValidationResult;
 
@@ -10,14 +12,12 @@ import java.util.ArrayList;
 public class CucumberGenerationConfigValidator implements ConfigValidator {
 
     @Override
-    public ValidationResult validatePreProfile(GenerationConfig config) {
+    public ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource configSource) {
         return new ValidationResult(new ArrayList<>());
     }
 
     @Override
-    public ValidationResult validateCommandLinePostProfile(Profile profile) {
+    public ValidationResult validateCommandLinePostProfile(Profile profile, GenerationConfigSource configSource, OutputTarget outputTarget) {
         return new ValidationResult(new ArrayList<>());
     }
-
-
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 public class CucumberGenerationConfigValidator implements ConfigValidator {
 
     @Override
-    public ValidationResult validateCommandLinePreProfile(GenerationConfig config) {
+    public ValidationResult validatePreProfile(GenerationConfig config) {
         return new ValidationResult(new ArrayList<>());
     }
 
@@ -18,4 +18,6 @@ public class CucumberGenerationConfigValidator implements ConfigValidator {
     public ValidationResult validateCommandLinePostProfile(Profile profile) {
         return new ValidationResult(new ArrayList<>());
     }
+
+
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberGenerationConfigValidator.java
@@ -12,12 +12,12 @@ import java.util.ArrayList;
 public class CucumberGenerationConfigValidator implements ConfigValidator {
 
     @Override
-    public ValidationResult validatePreProfile(GenerationConfig config, GenerationConfigSource configSource) {
+    public ValidationResult preProfileChecks(GenerationConfig config, GenerationConfigSource configSource) {
         return new ValidationResult(new ArrayList<>());
     }
 
     @Override
-    public ValidationResult validateCommandLinePostProfile(Profile profile, GenerationConfigSource configSource, OutputTarget outputTarget) {
+    public ValidationResult postProfileChecks(Profile profile, GenerationConfigSource configSource, OutputTarget outputTarget) {
         return new ValidationResult(new ArrayList<>());
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestModule.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestModule.java
@@ -9,6 +9,7 @@ import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.inputs.ProfileReader;
 import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
+import com.scottlogic.deg.generator.validators.ConfigValidator;
 import com.scottlogic.deg.generator.violations.ViolationGenerationEngine;
 
 /**
@@ -30,6 +31,7 @@ public class CucumberTestModule extends AbstractModule {
         bind(GenerationConfigSource.class).to(CucumberGenerationConfigSource.class);
         bind(OutputTarget.class).to(InMemoryOutputTarget.class).in(Singleton.class);
         bind(ManifestWriter.class).to(CucumberManifestWriter.class);
+        bind(ConfigValidator.class).to(CucumberGenerationConfigValidator.class);
 
         if (testState.shouldViolate) {
             bind(GenerationEngine.class).to(ViolationGenerationEngine.class);

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -45,8 +45,11 @@ public class GenerationConfigValidatorTests {
 
     @Test
     public void interestingWithNoMaxRowsReturnsValid() {
+        //Arrange
+
+
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertTrue(validationResult.isValid());
@@ -66,7 +69,7 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertTrue(validationResult.isValid());
@@ -85,7 +88,7 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertFalse(validationResult.isValid());
@@ -106,7 +109,7 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertTrue(validationResult.isValid());
@@ -126,7 +129,7 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertTrue(validationResult.isValid());
@@ -146,7 +149,7 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePreProfile(config);
+        ValidationResult validationResult = validator.validatePreProfile(config);
 
         //Assert
         Assert.assertTrue(validationResult.isValid());

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -45,22 +45,17 @@ public class GenerationConfigValidatorTests {
         errorMessages = new ArrayList<>();
     }
 
-    //first test has been refactored to new format
-    //validateCommandLineOptions replaces validatePreProfile and now returns the errorMessages array list rather than a validationResult
-    //fix the rest of the tests to match and write new tests for validateProfileInputFile method
-
     @Test
-    public void interestingWithNoMaxRowsReturnsValid() {
+    public void validateCommandLineOptions_validOptions_noErrorMessages() {
         //Act
         validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-//        Assert.assertTrue(validationResult.isValid());
         Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test
-    public void interestingWithMaxRowsReturnsValid() {
+    public void validateCommandLineOptions_interestingWithMaxRows_noErrorMessages() {
         //Arrange
         TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
             GenerationConfig.DataGenerationType.INTERESTING,
@@ -79,7 +74,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void randomWithNoMaxRowsReturnsNotValid() {
+    public void validateCommandLineOptions_randomWithNoMaxRows_correctErrorMessage() {
         //Arrange
         TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
             GenerationConfig.DataGenerationType.RANDOM,
@@ -97,7 +92,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void randomWithMaxRowsReturnsValid() {
+    public void validateCommandLineOptions_randomWithMaxRows_noErrorMessages() {
         //Arrange
         TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
             GenerationConfig.DataGenerationType.RANDOM,
@@ -116,7 +111,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void fullSequentialWithNoMaxRowsReturnsValid() {
+    public void validateCommandLineOptions_fullSequentialWithNoMaxRows_noErrorMessages() {
         //Arrange
         GenerationConfig config = new GenerationConfig(
             new TestGenerationConfigSource(
@@ -135,7 +130,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void fullSequentialWithMaxRowsReturnsValid() {
+    public void validateCommandLineOptions_fullSequentialWithMaxRows_noErrorMessages() {
         //Arrange
         TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
             GenerationConfig.DataGenerationType.FULL_SEQUENTIAL,
@@ -154,7 +149,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateOutputFileAlreadyExists() {
+    public void validateCommandLinePostProfile_generateOutputFileAlreadyExists_isNotValid() {
         //Arrange
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
 
@@ -167,7 +162,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateOutputFileAlreadyExistsCommandLineOverwrite() {
+    public void validateCommandLinePostProfile_generateOutputFileAlreadyExistsCommandLineOverwrite_isValid() {
         //Arrange
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
         when(mockConfigSource.overwriteOutputFiles()).thenReturn(true);
@@ -181,7 +176,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateOutputFileDoesNotExist() {
+    public void validateCommandLinePostProfile_generateOutputFileDoesNotExist_isValid() {
 
         //Act
         ValidationResult validationResult = validator
@@ -192,7 +187,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateOutputDirNotFile() {
+    public void validateCommandLinePostProfile_generateOutputDirNotFile_isNotValid() {
         //Arrange
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
 
@@ -205,7 +200,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateViolationOutputFileAlreadyExists() {
+    public void validateCommandLinePostProfile_generateViolationOutputFileAlreadyExists_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
@@ -219,7 +214,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateViolationOutputFileDoesNotExist() {
+    public void validateCommandLinePostProfile_generateViolationOutputFileDoesNotExist_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(false);
@@ -234,7 +229,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateViolationOutputDirNotExists() {
+    public void validateCommandLinePostProfile_generateViolationOutputDirNotExists_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
@@ -250,7 +245,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateViolationOutputDirNotFile() {
+    public void validateCommandLinePostProfile_generateViolationOutputDirNotFile_isValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
@@ -265,7 +260,7 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void generateViolationOutputDirNotEmpty() {
+    public void validateCommandLinePostProfile_generateViolationOutputDirNotEmpty_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -31,6 +31,7 @@ public class GenerationConfigValidatorTests {
     );
     private GenerationConfigValidator validator;
     private Profile profile;
+    private ArrayList<String> errorMessages;
     private TestGenerationConfigSource mockConfigSource = mock(TestGenerationConfigSource.class);
 
     @BeforeEach
@@ -41,19 +42,21 @@ public class GenerationConfigValidatorTests {
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
         when(mockConfigSource.shouldViolate()).thenReturn(false);
         profile = new Profile(new ArrayList<>(), new ArrayList<>());
+        errorMessages = new ArrayList<>();
     }
+
+    //first test has been refactored to new format
+    //validateCommandLineOptions replaces validatePreProfile and now returns the errorMessages array list rather than a validationResult
+    //fix the rest of the tests to match and write new tests for validateProfileInputFile method
 
     @Test
     public void interestingWithNoMaxRowsReturnsValid() {
-        //Arrange
-
-
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages, is(empty()));
+//        Assert.assertTrue(validationResult.isValid());
+        Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test
@@ -69,11 +72,10 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages, is(empty()));
+        Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test
@@ -88,12 +90,10 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages,
-            hasItem("RANDOM mode requires max row limit: use -n=<row limit> option"));
+        Assert.assertThat(errorMessages, hasItem("RANDOM mode requires max row limit: use -n=<row limit> option"));
     }
 
     @Test
@@ -109,11 +109,10 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages, is(empty()));
+        Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test
@@ -129,11 +128,10 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages, is(empty()));
+        Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test
@@ -149,11 +147,10 @@ public class GenerationConfigValidatorTests {
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        ValidationResult validationResult = validator.validatePreProfile(config);
+        validator.validateCommandLineOptions(config, errorMessages);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
-        Assert.assertThat(validationResult.errorMessages, is(empty()));
+        Assert.assertThat(errorMessages, is(empty()));
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -44,6 +44,7 @@ public class GenerationConfigValidatorTests {
         when(mockConfigSource.getProfileFile()).thenReturn(mockFile);
         //Pre Profile Checks
         when(config.getMaxRows()).thenReturn(Optional.empty());
+        when(mockConfigSource.isEnableTracing()).thenReturn(false);
         when(mockFile.exists()).thenReturn(true);
         when(mockFile.isDirectory()).thenReturn(false);
         when(mockFileUtils.containsInvalidChars(mockFile)).thenReturn(false);
@@ -95,6 +96,52 @@ public class GenerationConfigValidatorTests {
         //Assert
         assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
         Assert.assertFalse(actualResult.isValid());
+    }
+
+    @Test
+    public void validateCommandLineOptions_traceConstraintsOutputFileDoesNotExist_returnsNoErrorMessages() {
+        //Arrange
+        when(mockConfigSource.isEnableTracing()).thenReturn(true);
+        when(mockFileUtils.getTraceFile(mockConfigSource)).thenReturn(mock(File.class));
+
+        //Act
+        ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);
+
+        //Assert
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
+    }
+
+    @Test
+    public void validateCommandLineOptions_traceConstraintsOutputFileAlreadyExistsNoOverwrite_returnsCorrectErrorMessage() {
+        //Arrange
+        when(mockConfigSource.isEnableTracing()).thenReturn(true);
+        when(mockFileUtils.getTraceFile(mockConfigSource)).thenReturn(mock(File.class));
+        when(mockFileUtils.getTraceFile(mockConfigSource).exists()).thenReturn(true);
+        expectedErrorMessages.add("Invalid Output - trace file already exists, please use a different output filename or use the --overwrite option");
+
+        //Act
+        ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);
+
+        //Assert
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
+    }
+
+    @Test
+    public void validateCommandLineOptions_traceConstraintsOutputFileAlreadyExistsOverwrite_returnsNoErrorMessages() {
+        //Arrange
+        when(mockConfigSource.isEnableTracing()).thenReturn(true);
+        when(mockFileUtils.getTraceFile(mockConfigSource)).thenReturn(mock(File.class));
+        when(mockFileUtils.getTraceFile(mockConfigSource).exists()).thenReturn(true);
+        when(mockConfigSource.overwriteOutputFiles()).thenReturn(true);
+
+        //Act
+        ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);
+
+        //Assert
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -34,7 +32,7 @@ public class GenerationConfigValidatorTests {
     private TestGenerationConfigSource mockConfigSource = mock(TestGenerationConfigSource.class);
 
     @BeforeEach
-    void setup() throws IOException {
+    void setup() {
         //Arrange
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
         profile = new Profile(new ArrayList<>(), new ArrayList<>());
@@ -50,7 +48,6 @@ public class GenerationConfigValidatorTests {
         when(mockFile.isDirectory()).thenReturn(false);
         when(mockFileUtils.containsInvalidChars(mockFile)).thenReturn(false);
         when(mockFileUtils.isFileEmpty(mockFile)).thenReturn(false);
-        when(mockFileUtils.probeContentType(any(Path.class))).thenReturn("application/json");
         //Post Profile Checks
         when(mockFileUtils.exists(mockOutputTarget)).thenReturn(true);
         when(mockFileUtils.isDirectory(mockOutputTarget)).thenReturn(false);
@@ -148,21 +145,6 @@ public class GenerationConfigValidatorTests {
         //Arrange
         when(mockFileUtils.isFileEmpty(mockFile)).thenReturn(true);
         expectedErrorMessages.add("Invalid Input - Profile file has no content");
-
-        //Act
-        ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);
-
-        //Assert
-        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
-        Assert.assertFalse(actualResult.isValid());
-    }
-
-    @Test
-    public void preProfileChecks_profileFileNotTypeJSON_returnsCorrectErrorMessage() throws IOException {
-        //Arrange
-        when(mockFileUtils.probeContentType(mockFile.toPath())).thenReturn("invalid_file_type");
-        expectedErrorMessages.add("Invalid Input - File is of type invalid_file_type" +
-            "\nFile type application/json required");
 
         //Act
         ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -313,7 +313,7 @@ public class GenerationConfigValidatorTests {
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
         when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(false);
-        expectedErrorMessages.add("Invalid Output - directory not empty, please remove any 'manfiest.json' " +
+        expectedErrorMessages.add("Invalid Output - directory not empty, please remove any 'manifest.json' " +
             "and '[0-9].csv' files or use the --overwrite option");
 
         //Act

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -8,157 +8,184 @@ import com.scottlogic.deg.generator.utils.FileUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Optional;
 
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static com.shazam.shazamcrest.MatcherAssert.assertThat;
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs;
 import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class GenerationConfigValidatorTests {
 
     private FileOutputTarget mockOutputTarget = mock(FileOutputTarget.class);
     private FileUtils mockFileUtils = mock(FileUtils.class);
-    private GenerationConfig config = new GenerationConfig(
-        new TestGenerationConfigSource(
-            GenerationConfig.DataGenerationType.INTERESTING,
-            GenerationConfig.TreeWalkerType.REDUCTIVE,
-            GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-        )
-    );
+    private File mockFile = mock(File.class);
+    private GenerationConfig config = mock(GenerationConfig.class);
     private GenerationConfigValidator validator;
     private Profile profile;
-    private ArrayList<String> errorMessages;
+    private ArrayList<String> expectedErrorMessages;
+    private ValidationResult expectedResult;
     private TestGenerationConfigSource mockConfigSource = mock(TestGenerationConfigSource.class);
 
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
         //Arrange
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
-        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(false);
-        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
+
+        when(mockFileUtils.isDirectory(mockOutputTarget)).thenReturn(false);
+        when(mockFileUtils.exists(mockOutputTarget)).thenReturn(true);
+        when(mockFileUtils.probeContentType(any(Path.class))).thenReturn("application/json");
         when(mockConfigSource.shouldViolate()).thenReturn(false);
+        when(mockConfigSource.getProfileFile()).thenReturn(mockFile);
+        when(mockFile.exists()).thenReturn(true);
+        when(mockConfigSource.getMaxRows()).thenReturn(null);
+        when(config.getDataGenerationType()).thenReturn(GenerationConfig.DataGenerationType.INTERESTING);
+        when(config.getMaxRows()).thenReturn(Optional.empty());
+        when(mockFileUtils.containsInvalidChars(mockFile)).thenReturn(false);
+        when(mockFile.exists()).thenReturn(true);
+        when(mockFile.isDirectory()).thenReturn(false);
+        when(mockFileUtils.isEmpty(mockFile)).thenReturn(false);
+
         profile = new Profile(new ArrayList<>(), new ArrayList<>());
-        errorMessages = new ArrayList<>();
+        expectedErrorMessages = new ArrayList<>();
+        expectedResult = new ValidationResult(expectedErrorMessages);
     }
 
     @Test
-    public void validateCommandLineOptions_validOptions_noErrorMessages() {
+    public void validatePreProfile_withValid_returnsNoErrorMessages() {
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, is(empty()));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLineOptions_interestingWithMaxRows_noErrorMessages() {
+    public void validatePreProfile_randomWithMaxRows_returnsNoErrorMessages() {
         //Arrange
-        TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
-            GenerationConfig.DataGenerationType.INTERESTING,
-            GenerationConfig.TreeWalkerType.REDUCTIVE,
-            GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-        );
-        testConfigSource.setMaxRows(1234567L);
-        GenerationConfig config = new GenerationConfig(testConfigSource);
+        Mockito.reset(config);
+        when(config.getDataGenerationType()).thenReturn(GenerationConfig.DataGenerationType.RANDOM);
+        when(config.getMaxRows()).thenReturn(Optional.of(1234L));
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, is(empty()));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test
     public void validateCommandLineOptions_randomWithNoMaxRows_correctErrorMessage() {
         //Arrange
-        TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
-            GenerationConfig.DataGenerationType.RANDOM,
-            GenerationConfig.TreeWalkerType.REDUCTIVE,
-            GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-        );
-        GenerationConfig config = new GenerationConfig(testConfigSource);
+        Mockito.reset(config);
+        when(config.getDataGenerationType()).thenReturn(GenerationConfig.DataGenerationType.RANDOM);
+        when(config.getMaxRows()).thenReturn(Optional.empty());
+        expectedErrorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
         validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
 
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, hasItem("RANDOM mode requires max row limit: use -n=<row limit> option"));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLineOptions_randomWithMaxRows_noErrorMessages() {
+    public void validatePreProfile_profileFilePathContainsInvalidChars_returnsCorrectErrorMessage() {
         //Arrange
-        TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
-            GenerationConfig.DataGenerationType.RANDOM,
-            GenerationConfig.TreeWalkerType.REDUCTIVE,
-            GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-        );
-        testConfigSource.setMaxRows(1234567L);
-        GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
+        when(mockFileUtils.containsInvalidChars(mockFile)).thenReturn(true);
+        expectedErrorMessages.add(String.format("Profile file path (%s) contains one or more invalid characters " +
+            "? : %% \" | > < ", mockFile.toString()));
 
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, is(empty()));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLineOptions_fullSequentialWithNoMaxRows_noErrorMessages() {
+    public void validatePreProfile_profileFileDoesNotExist_returnsCorrectErrorMessage() {
         //Arrange
-        GenerationConfig config = new GenerationConfig(
-            new TestGenerationConfigSource(
-                GenerationConfig.DataGenerationType.FULL_SEQUENTIAL,
-                GenerationConfig.TreeWalkerType.REDUCTIVE,
-                GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-            )
-        );
-        validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
+        when(mockFile.exists()).thenReturn(false);
+        expectedErrorMessages.add("Invalid Input - Profile file does not exist");
 
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, is(empty()));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLineOptions_fullSequentialWithMaxRows_noErrorMessages() {
+    public void validatePreProfile_profileFileIsDir_returnsCorrectErrorMessage() {
         //Arrange
-        TestGenerationConfigSource testConfigSource = new TestGenerationConfigSource(
-            GenerationConfig.DataGenerationType.FULL_SEQUENTIAL,
-            GenerationConfig.TreeWalkerType.REDUCTIVE,
-            GenerationConfig.CombinationStrategyType.EXHAUSTIVE
-        );
-        testConfigSource.setMaxRows(1234567L);
-        GenerationConfig config = new GenerationConfig(testConfigSource);
-        validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
+        when(mockFile.isDirectory()).thenReturn(true);
+        expectedErrorMessages.add("Invalid Input - Profile file path provided is to a directory");
 
         //Act
-        validator.validateCommandLineOptions(config, errorMessages);
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
 
         //Assert
-        Assert.assertThat(errorMessages, is(empty()));
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
+    }
+
+    @Test
+    public void validatePreProfile_profileFileIsEmpty_returnsCorrectErrorMessage() {
+        //Arrange
+        when(mockFileUtils.isEmpty(mockFile)).thenReturn(true);
+        expectedErrorMessages.add("Invalid Input - Profile file has no content");
+
+        //Act
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
+
+        //Assert
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
+    }
+
+    @Test
+    public void validateProfileInputFile_profileFileNotTypeJSON_correctErrorMessage() throws IOException {
+        //Arrange
+        when(mockFileUtils.probeContentType(mockFile.toPath())).thenReturn("invalid_file_type");
+        expectedErrorMessages.add("Invalid Input - File is of type invalid_file_type" +
+            "\nFile type application/json required");
+
+        //Act
+        ValidationResult actualResult = validator.validatePreProfile(config, mockConfigSource);
+
+        //Assert
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
     public void validateCommandLinePostProfile_generateOutputFileAlreadyExists_isNotValid() {
         //Arrange
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
+        expectedErrorMessages.add("Invalid Output - file already exists, please use a different output filename " +
+            "or use the --overwrite option");
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
@@ -168,95 +195,90 @@ public class GenerationConfigValidatorTests {
         when(mockConfigSource.overwriteOutputFiles()).thenReturn(true);
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test
     public void validateCommandLinePostProfile_generateOutputFileDoesNotExist_isValid() {
+        //Arrange
+        when(mockFileUtils.exists(mockOutputTarget)).thenReturn(false);
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertTrue(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test
     public void validateCommandLinePostProfile_generateOutputDirNotFile_isNotValid() {
         //Arrange
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
+        expectedErrorMessages.add("Invalid Output - target is a directory, please use a different output filename");
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLinePostProfile_generateViolationOutputFileAlreadyExists_isNotValid() {
+    public void validateCommandLinePostProfile_generateViolationOutputFileNotDir_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
+        expectedErrorMessages.add("Invalid Output - not a directory, please enter a valid directory name");
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLinePostProfile_generateViolationOutputFileDoesNotExist_isNotValid() {
+    public void validateCommandLinePostProfile_generateViolationOutputDirDoesNotExist_isNotValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(false);
         when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
+        expectedErrorMessages.add("Invalid Output - output directory must exist, please enter a valid directory name");
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
 
     @Test
-    public void validateCommandLinePostProfile_generateViolationOutputDirNotExists_isNotValid() {
+    public void validateCommandLinePostProfile_generateViolationValid_isValid() {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
         when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(true);
 
         //Act
-        ValidationResult validationResult = validator
-            .validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator
+            .validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
-    }
-
-    @Test
-    public void validateCommandLinePostProfile_generateViolationOutputDirNotFile_isValid() {
-        //Arrange
-        when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(true);
-        when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
-        when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(true);
-
-        //Act
-        ValidationResult validationResult = validator.validateCommandLinePostProfile(profile);
-
-        //Assert
-        Assert.assertTrue(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertTrue(actualResult.isValid());
     }
 
     @Test
@@ -265,12 +287,14 @@ public class GenerationConfigValidatorTests {
         when(mockConfigSource.shouldViolate()).thenReturn(true);
         when(mockFileUtils.isDirectory(eq(mockOutputTarget))).thenReturn(true);
         when(mockFileUtils.isDirectoryEmpty(eq(mockOutputTarget), anyInt())).thenReturn(false);
+        expectedErrorMessages.add("Invalid Output - directory not empty, please remove any 'manfiest.json' " +
+            "and '[0-9].csv' files or use the --overwrite option");
 
         //Act
-        ValidationResult validationResult = validator.validateCommandLinePostProfile(profile);
+        ValidationResult actualResult = validator.validateCommandLinePostProfile(profile, mockConfigSource, mockOutputTarget);
 
         //Assert
-        Assert.assertFalse(validationResult.isValid());
+        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
+        Assert.assertFalse(actualResult.isValid());
     }
-
 }


### PR DESCRIPTION
### Description
Added checks to the `GenerationConfigValidator` for the profile file to prevent the Google Guice provisioning errors.

### Changes
 - Added Pre Profile Checks for: 
       - Profile file not existing
       - Profile file path containing invalid chars
       - Profile file path pointing to a directory
       - Profile file having no content
       - Profile file having non json content
 - Added `ConfigValidator` interface to aid with cucumber testing and to allow for future config validators to be added 
 - Refactored `GenerationConfigValidator` slightly including renaming methods for clarity
 - Added tests
 - Renamed existing tests to follow suggested  naming convention

Resolves #567 