### PR TITLE
596- cucumber test performance

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
@@ -230,7 +230,7 @@ Scenario: Running a 'shorterThan' request alongside a lessThanOrEqualTo constrai
        | ""   |
        | null |
 
-@ignore
+@ignore #91 values are emitted from both constraints in the anyOf, where they should be 'unique' for the field
 Scenario: Running a 'shorterThan' request as part of a non-contradicting anyOf constraint should be successful
      Given there is a constraint:
        """

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
@@ -198,43 +198,37 @@ Scenario: Running a 'shorterThan' request alongside a non-contradicting shorterT
        | "♀"  |
        | "♀♀" |
 
-@ignore
 Scenario: Running a 'shorterThan' request alongside a greaterThan constraint should be successful
-     Given foo is shorter than 10
+     Given foo is shorter than 1
        And foo is greater than 8
-       And foo is matching regex /[a]{1,10}/
      Then the following data should be generated:
-       | foo         |
-       | "aaaaaaaaa" |
-       | null        |
+       | foo  |
+       | ""   |
+       | null |
 
-@ignore
 Scenario: Running a 'shorterThan' request alongside a greaterThanOrEqualTo constraint should be successful
-     Given foo is shorter than 3
+     Given foo is shorter than 1
        And foo is greater than or equal to 2
-       And foo is matching regex /[a]{1,10}/
      Then the following data should be generated:
-       | foo    |
-       | "aa"   |
-       | null   |
+       | foo  |
+       | ""   |
+       | null |
 
 Scenario: Running a 'shorterThan' request alongside a lessThan constraint should be successful
-     Given foo is shorter than 2
+     Given foo is shorter than 1
        And foo is less than 15
-       And foo is matching regex /[a]{1,10}/
      Then the following data should be generated:
-       | foo    |
-       | "a"    |
-       | null   |
+       | foo  |
+       | ""   |
+       | null |
 
 Scenario: Running a 'shorterThan' request alongside a lessThanOrEqualTo constraint should be successful
-     Given foo is shorter than 2
+     Given foo is shorter than 1
        And foo is less than or equal to 19
-       And foo is matching regex /[a]{1,10}/
      Then the following data should be generated:
-       | foo    |
-       | "a"    |
-       | null   |
+       | foo  |
+       | ""   |
+       | null |
 
 @ignore
 Scenario: Running a 'shorterThan' request as part of a non-contradicting anyOf constraint should be successful


### PR DESCRIPTION
### Description
Some of our cucumber tests are running slower than they can, incurring time delays and additional compute costs for each pull request check

### Changes
- Change each identified scenario in #596 to produce less data
- Updated unaffected scenario to reference related ticket explaining why its ignored

### Additional context
- All cucumber 937 scenarios run and pass in following times: 10.251s, 10.270s, 9.412s, 9.117s, 8.995s - avg: ~9.6s
- All 1665 tests for the generator run and pass in 11.672s, 10.35s, 10.642s - avg: ~10.9s
- `ShorterThan.feature` is the only affected file

### Issue
Resolves #596