### PR TITLE
607 & 608 cucumber before min date

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Before.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Before.feature
@@ -149,16 +149,6 @@ Scenario: Running a 'before' request that specifies the maximum valid system dat
        | 9999-12-31T23:59:59.996 |
        | 9999-12-31T23:59:59.995 |
 
-# Defect 600 "Running a before constraint in full generation mode generates interesting data" related to this scenario
-# Defect 607 "Setting Before 0001-01-01T00:00:00.000 loops round to december of that year" related to this scenario
-# Defect 608 "Setting a date of 0000-01-01T00:00:00.000 results in an error" related to this scenario
-@ignore
-Scenario: Running a 'before' request that specifies the lowest valid system date should only generate null data
-     Given foo is before 0000-01-01T00:00:00.000
-     Then the following data should be generated:
-       | foo                     |
-       | null                    |
-
 Scenario: Running a 'before' request that specifies an invalid date should be unsuccessful
      Given foo is before 2019-30-30T00:00:00.000
      Then the profile is invalid

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberProfileReader.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberProfileReader.java
@@ -49,13 +49,13 @@ public class CucumberProfileReader implements ProfileReader {
             }).collect(Collectors.toList());
 
             if (exceptionInMapping.get()){
-                return null;
+                return new Profile(Collections.emptyList(), Collections.emptySet(), "Error creating profile");
             }
 
             return new Profile(profileFields, Collections.singletonList(new Rule(new RuleInformation(new RuleDTO()), mappedConstraints)));
         } catch (Exception e) {
             state.addException(e);
-            return null;
+            return new Profile(Collections.emptyList(), Collections.emptySet(), "Error creating profile: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Description
Cucumber framework throws a null-pointer exception as well as profile exceptions when a profile is invalid. This hides some detail for an issue surrounding why a scenario doesn't work. This was noticed when reviewing issues for #607.

There is a _Before_ scenario which attempts to create temporal values before 0000-01-01, which isn't currently supported. [ISO-8601]() describe how dates should be constrained to positive 4 digit years except where otherwise agreed. #636 has been created to document this range more clearly in `DataTypes.md`.

### Changes
- Remove erroneous scenario
- Update cucumber to ensure `NullPointerException` is not thrown when a profile is deemed invalid

### Issue
Resolves #607 
Resolves #608
Relates to #636 