### PR TITLE
create output directory for violation

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/FileUtils.java
@@ -93,15 +93,27 @@ public class FileUtils {
      * we wrap Files.createDirectories() so that we can mock it out in unit tests.
      *
      * @param dir the directory we want to create
-     * @return true is the directory was created successfully, false if the parent directory already exists
+     * @return true is the directory was created successfully,
+     * false if the parent already exists and is a file
      * @throws IOException if we are unable to create the directory due to an I/O error
      */
     public boolean createDirectories(Path dir) throws IOException {
         try {
+            checkValidDirectoryPath(dir);
             Files.createDirectories(dir);
         } catch (FileAlreadyExistsException e) {
             return false;
         }
         return true;
+    }
+
+    private void checkValidDirectoryPath(Path dir) throws FileAlreadyExistsException {
+        if (Files.exists(dir) && !Files.isDirectory(dir)) {
+            throw new FileAlreadyExistsException("Directory name exists as file");
+        }
+        Path prntDir = dir.getParent();
+        if (prntDir != null) {
+            checkValidDirectoryPath(prntDir);
+        }
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -105,8 +105,7 @@ public class GenerationConfigValidator implements ConfigValidator {
             errorMessages.add(
                 "Invalid Output - file already exists, please use a different output filename or use the --overwrite option");
         } else if (!fileUtils.exists(outputTarget)) {
-            Path parent = outputTarget.getFilePath().normalize().toAbsolutePath().getParent();
-            parent = outputTarget.getFilePath().toAbsolutePath().getParent();
+            Path parent = outputTarget.getFilePath().toAbsolutePath().getParent();
             if (!fileUtils.createDirectories(parent)) {
                 errorMessages.add(
                     "Invalid Output - parent directory of output file already exists but is not a directory, please use a different output filename");
@@ -117,10 +116,9 @@ public class GenerationConfigValidator implements ConfigValidator {
     private void checkViolationGenerateOutputTarget(ArrayList<String> errorMessages,
                                                     GenerationConfigSource configSource,
                                                     FileOutputTarget outputTarget,
-                                                    int ruleCount) {
+                                                    int ruleCount) throws IOException {
         if (!fileUtils.exists(outputTarget)) {
-            errorMessages.add(
-                "Invalid Output - output directory must exist, please enter a valid directory name");
+            fileUtils.createDirectories(outputTarget.getFilePath());
         } else if (!fileUtils.isDirectory(outputTarget)) {
             errorMessages
                 .add("Invalid Output - not a directory, please enter a valid directory name");

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -315,22 +315,6 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void postProfileChecks_generateViolationOutputDirDoesNotExist_isNotValid() throws IOException {
-        //Arrange
-        when(mockConfigSource.shouldViolate()).thenReturn(true);
-        when(mockFileUtils.exists(eq(mockOutputTarget))).thenReturn(false);
-        expectedErrorMessages.add("Invalid Output - output directory must exist, please enter a valid directory name");
-
-        //Act
-        ValidationResult actualResult = validator
-            .postProfileChecks(profile, mockConfigSource, mockOutputTarget);
-
-        //Assert
-        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
-        Assert.assertFalse(actualResult.isValid());
-    }
-
-    @Test
     public void postProfileChecks_generateViolationValid_isValid() throws IOException {
         //Arrange
         when(mockConfigSource.shouldViolate()).thenReturn(true);


### PR DESCRIPTION
### Description
Automatically create output directory for violation
Fix creating directory when any part of the path is a pre-existing file

Resolves #637 