### PR TITLE
680- Remove parallel combination for output consistency

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/ExhaustiveCombinationStrategy.java
@@ -15,7 +15,7 @@ public class ExhaustiveCombinationStrategy implements CombinationStrategy {
 
         List<List<DataBag>> bagsAsLists = dataBagSequences
             .map(sequence ->
-                StreamSupport.stream(sequence.spliterator(), true)
+                StreamSupport.stream(sequence.spliterator(), false)
                     .collect(Collectors.toList()))
             .collect(Collectors.toList());
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategy.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/combinationstrategies/PinningCombinationStrategy.java
@@ -17,7 +17,7 @@ public class PinningCombinationStrategy implements CombinationStrategy {
         Iterable<DataBag> iterable = new PinningCombinationStrategy
                 .InternalIterable(dataBagSequences);
 
-        return StreamSupport.stream(iterable.spliterator(), true);
+        return StreamSupport.stream(iterable.spliterator(), false);
     }
 
     class InternalIterable implements Iterable<DataBag> {

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/GreaterThan.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/GreaterThan.feature
@@ -5,8 +5,6 @@ Background:
        And there is a field foo
        And foo is of type "numeric"
 
-#Intermittently failing test - Issue #680
-@ignore
 Scenario: Running a 'greaterThan' request that specifies an integer should be successful
      Given foo is greater than 1
 	   And foo is anything but null
@@ -196,8 +194,6 @@ Scenario: greaterThan run against a non contradicting lessThan should be success
        | 3   |
        | 4   |
 
-#Intermittently failing test - Issue #680
-@ignore
 Scenario: greaterThan run against a non contradicting not lessThan should be successful (greaterThan 1 AND not lessThan 2)
      Given foo is greater than 1
        And foo is anything but less than 2
@@ -260,8 +256,6 @@ Scenario: greaterThan run against a non contradicting lessThanOrEqualTo should b
        | 4   |
        | 5   |
 
-#Intermittently failing test - Issue #680
-@ignore
 Scenario: greaterThan run against a non contradicting not lessThanOrEqualTo should be successful
    Given foo is greater than 1
      And foo is anything but less than or equal to 2


### PR DESCRIPTION
### Description
Some tests in the `GreaterThan.feature` file fail intermittently.

### Changes
- Remove parallel stream processing to provide more consistency in the output

### Testing notes
- GreaterThan.feature (1.6s-1.8s - 3 samples) vs (1.8s-2.3s - 3 samples) [original]
- All tests (12.6s-13.7s - 3 samples) vs (12.6s-13.2s - 3 samples) [original]

### Issue
Resolves #680