### PR TITLE
Include bug label by default for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: If something isn't working as expected 🤔.
-
+labels: bug
 ---
 
 ## Bug Report


### PR DESCRIPTION
### Description
Bug label is often missed from bug reports, [GitHub supports](https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters#supported-query-parameters) the definition of default labels per issue type/template.

### Changes
- Set `bug` as a default label for bug reports

### Issue
Not related to an issue