### PR TITLE
635- datetime & numeric merge fixes

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperation.java
@@ -1,16 +1,22 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.google.inject.Inject;
 import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import java.util.Optional;
 
 public class DateTimeRestrictionsMergeOperation implements RestrictionMergeOperation {
-    private static final DateTimeRestrictionsMerger dateTimeRestrictionsMerger = new DateTimeRestrictionsMerger();
+    private final DateTimeRestrictionsMerger merger;
+
+    @Inject
+    public DateTimeRestrictionsMergeOperation(DateTimeRestrictionsMerger merger) {
+        this.merger = merger;
+    }
 
     @Override
     public Optional<FieldSpec> applyMergeOperation(FieldSpec left, FieldSpec right, FieldSpec merging) {
-        DateTimeRestrictions dateTimeRestrictions = dateTimeRestrictionsMerger.merge(
+        DateTimeRestrictions dateTimeRestrictions = merger.merge(
             left.getDateTimeRestrictions(), right.getDateTimeRestrictions());
 
         if (dateTimeRestrictions == null) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -1,5 +1,7 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
+import com.scottlogic.deg.generator.restrictions.DateTimeRestrictionsMerger;
+
 import java.util.Optional;
 
 /**
@@ -11,7 +13,7 @@ public class FieldSpecMerger {
     private static final RestrictionMergeOperation[] mergeOperations = new RestrictionMergeOperation[]{
         new StringRestrictionsMergeOperation(),
         new NumericRestrictionsMergeOperation(),
-        new DateTimeRestrictionsMergeOperation(),
+        new DateTimeRestrictionsMergeOperation(new DateTimeRestrictionsMerger()),
         new NullRestrictionsMergeOperation(),
         new FormatRestrictionsMergeOperation(),
         new GranularityRestrictionsMergeOperation(),

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/FieldSpecMerger.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
 import com.scottlogic.deg.generator.restrictions.DateTimeRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.NumericRestrictionsMerger;
 
 import java.util.Optional;
 
@@ -12,7 +13,7 @@ public class FieldSpecMerger {
 
     private static final RestrictionMergeOperation[] mergeOperations = new RestrictionMergeOperation[]{
         new StringRestrictionsMergeOperation(),
-        new NumericRestrictionsMergeOperation(),
+        new NumericRestrictionsMergeOperation(new NumericRestrictionsMerger()),
         new DateTimeRestrictionsMergeOperation(new DateTimeRestrictionsMerger()),
         new NullRestrictionsMergeOperation(),
         new FormatRestrictionsMergeOperation(),

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
 import com.google.inject.Inject;
+import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import java.util.Optional;
@@ -19,14 +20,20 @@ public class NumericRestrictionsMergeOperation implements RestrictionMergeOperat
             left.getNumericRestrictions(), right.getNumericRestrictions());
 
         if (!mergeResult.successful) {
-            return Optional.empty();
+            TypeRestrictions typeRestrictions = merging.getTypeRestrictions();
+            if (typeRestrictions == null){
+                typeRestrictions = DataTypeRestrictions.ALL_TYPES_PERMITTED;
+            }
+
+            return Optional.of(merging
+                .withTypeRestrictions(
+                    typeRestrictions.except(IsOfTypeConstraint.Types.NUMERIC),
+                    left.getFieldSpecSource().combine(right.getFieldSpecSource())));
         }
 
         NumericRestrictions numberRestrictions = mergeResult.restrictions;
         if (numberRestrictions == null) {
-            return Optional.of(merging.withNumericRestrictions(
-                null,
-                FieldSpecSource.Empty));
+            return Optional.of(merging);
         }
 
         return Optional.of(merging

--- a/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperation.java
@@ -1,16 +1,21 @@
 package com.scottlogic.deg.generator.fieldspecs;
 
-import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
+import com.google.inject.Inject;
 import com.scottlogic.deg.generator.restrictions.*;
 
 import java.util.Optional;
 
 public class NumericRestrictionsMergeOperation implements RestrictionMergeOperation {
-    private static final NumericRestrictionsMerger numericRestrictionsMerger = new NumericRestrictionsMerger();
+    private final NumericRestrictionsMerger merger;
+
+    @Inject
+    public NumericRestrictionsMergeOperation(NumericRestrictionsMerger merger) {
+        this.merger = merger;
+    }
 
     @Override
     public Optional<FieldSpec> applyMergeOperation(FieldSpec left, FieldSpec right, FieldSpec merging) {
-        MergeResult<NumericRestrictions> mergeResult = numericRestrictionsMerger.merge(
+        MergeResult<NumericRestrictions> mergeResult = merger.merge(
             left.getNumericRestrictions(), right.getNumericRestrictions());
 
         if (!mergeResult.successful) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/validators/TemporalConstraintValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/validators/TemporalConstraintValidator.java
@@ -29,10 +29,10 @@ public class TemporalConstraintValidator implements ConstraintValidatorAlerts {
 
         DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
 
-        DateTimeRestrictions result = merger.merge(currentRestrictions, candidateRestrictions);
+        MergeResult<DateTimeRestrictions> result = merger.merge(currentRestrictions, candidateRestrictions);
 
-        if (result != null) {
-            currentRestrictions = result;
+        if (result.successful) {
+            currentRestrictions = result.restrictions;
 
             if (isRangeInvalid() ) {
                 logInformation(field, referenceValue);
@@ -51,10 +51,10 @@ public class TemporalConstraintValidator implements ConstraintValidatorAlerts {
 
         DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
 
-        DateTimeRestrictions result = merger.merge(currentRestrictions, candidateRestrictions);
+        MergeResult<DateTimeRestrictions> result = merger.merge(currentRestrictions, candidateRestrictions);
 
-        if (result != null) {
-            currentRestrictions = result;
+        if (result.successful) {
+            currentRestrictions = result.restrictions;
 
             if (isRangeInvalid() ) {
                 logInformation(field, referenceValue);

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
@@ -27,6 +27,10 @@ public class DataTypeRestrictions implements TypeRestrictions {
         ArrayList<IsOfTypeConstraint.Types> allowedTypes = new ArrayList<>(this.allowedTypes);
         allowedTypes.removeAll(Arrays.asList(types));
 
+        if (allowedTypes.isEmpty()){
+            return NO_TYPES_PERMITTED;
+        }
+
         return new DataTypeRestrictions(allowedTypes);
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
@@ -5,13 +5,13 @@ public class DateTimeRestrictionsMerger {
         MIN, MAX
     }
 
-    public DateTimeRestrictions merge(DateTimeRestrictions left, DateTimeRestrictions right) {
+    public MergeResult<DateTimeRestrictions> merge(DateTimeRestrictions left, DateTimeRestrictions right) {
         if (left == null && right == null)
-            return null;
+            return new MergeResult<>(null);
         if (left == null)
-            return right;
+            return new MergeResult<>(right);
         if (right == null)
-            return left;
+            return new MergeResult<>(left);
 
         final DateTimeRestrictions merged = new DateTimeRestrictions();
 
@@ -19,10 +19,10 @@ public class DateTimeRestrictionsMerger {
         merged.max = getMergedLimitStructure(MergeLimit.MAX, left.max, right.max);
 
         if (merged.min.getLimit().isAfter(merged.max.getLimit())) {
-            return null;
+            return new MergeResult<>();
         }
 
-        return merged;
+        return new MergeResult<>(merged);
     }
 
     private DateTimeRestrictions.DateTimeLimit getMergedLimitStructure(

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
@@ -40,10 +40,10 @@ public class NumericRestrictionsMerger {
         }
 
         if (min.isInclusive() && max.isInclusive()){
-            return min.getLimit().compareTo(max.getLimit()) <= 0; //i.e. min is less than max
+            return min.getLimit().compareTo(max.getLimit()) <= 0; //i.e. min <= max
         }
 
-        return min.getLimit().compareTo(max.getLimit()) < 0; //i.e. min is less than max
+        return min.getLimit().compareTo(max.getLimit()) < 0; //i.e. min < max
     }
 
     private NumericLimit<BigDecimal> getMergedLimitStructure(MergeLimit mergeLimit, NumericLimit<BigDecimal> left, NumericLimit<BigDecimal> right) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
@@ -21,11 +21,22 @@ public class NumericRestrictionsMerger {
 
         final NumericRestrictions merged = new NumericRestrictions();
 
-
         merged.min = getMergedLimitStructure(MergeLimit.MIN, left.min, right.min);
         merged.max = getMergedLimitStructure(MergeLimit.MAX, left.max, right.max);
 
+        if (!canEmitSomeNumericValues(merged)){
+            return new MergeResult<>(); //successful = false
+        }
+
         return new MergeResult<>(merged);
+    }
+
+    private boolean canEmitSomeNumericValues(NumericRestrictions merged) {
+        if (merged.min == null || merged.max == null){
+            return true; //no constraints
+        }
+
+        return merged.min.getLimit().compareTo(merged.max.getLimit()) < 0; //i.e. min is less than max
     }
 
     private NumericLimit<BigDecimal> getMergedLimitStructure(MergeLimit mergeLimit, NumericLimit<BigDecimal> left, NumericLimit<BigDecimal> right) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMerger.java
@@ -32,11 +32,18 @@ public class NumericRestrictionsMerger {
     }
 
     private boolean canEmitSomeNumericValues(NumericRestrictions merged) {
-        if (merged.min == null || merged.max == null){
+        NumericLimit<BigDecimal> min = merged.min;
+        NumericLimit<BigDecimal> max = merged.max;
+
+        if (min == null || max == null){
             return true; //no constraints
         }
 
-        return merged.min.getLimit().compareTo(merged.max.getLimit()) < 0; //i.e. min is less than max
+        if (min.isInclusive() && max.isInclusive()){
+            return min.getLimit().compareTo(max.getLimit()) <= 0; //i.e. min is less than max
+        }
+
+        return min.getLimit().compareTo(max.getLimit()) < 0; //i.e. min is less than max
     }
 
     private NumericLimit<BigDecimal> getMergedLimitStructure(MergeLimit mergeLimit, NumericLimit<BigDecimal> left, NumericLimit<BigDecimal> right) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/After.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/After.feature
@@ -220,8 +220,6 @@ Then the following data should be generated:
   | 2018-01-01T00:00:00.003 |
   | 2018-01-01T00:00:00.004 |
 
-#Defect #673 - After: Request for contradictory After and Before should only generate null
-@ignore
 Scenario: 'Not After' with contradicting 'Not Before' only generates null
 Given foo is anything but after 2019-01-01T00:00:00.000
   And foo is anything but before 2019-01-02T00:00:00.000
@@ -229,8 +227,6 @@ Then the following data should be generated:
     | foo                     |
     | null                    |
 
-#Defect #673 - After: Request for contradictory After and Before should only generate null
-@ignore
 Scenario: 'After' with a contradicting 'Before' only generates null
 Given foo is after 2019-01-02T00:00:00.000
   And foo is before 2019-01-01T00:00:00.000
@@ -296,8 +292,6 @@ Then the following data should be generated:
   | 2018-01-01T00:00:00.004 |
   | 2018-01-01T00:00:00.005 |
 
-#Defect #673 - After: Request for contradictory After and Before should only generate null
-@ignore
 Scenario: 'After' with a contradicting 'Before Or At' only generates null
 Given foo is after 2019-01-02T00:00:00.000
   And foo is before or at 2019-01-01T00:00:00.000
@@ -305,8 +299,6 @@ Then the following data should be generated:
   | foo                     |
   | null                    |
 
-#Defect #673 - After: Request for contradictory After and Before should only generate null
-@ignore
 Scenario: 'Not After' with a contradicting not 'Before Or At' only generates null
 Given foo is anything but after 2019-01-01T00:00:00.000
   And foo is anything but before or at 2019-01-02T00:00:00.000

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Before.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Before.feature
@@ -190,8 +190,6 @@ Scenario: 'before' run against a contradicting 'beforeOrAt' should only only gen
        | foo                     |
        | null                    |
 
-# Defect 635 "DateTimeRestrictionsMergeOperation if contradictory, removes all dateTime restrictions" related to this scenario
-@ignore
 Scenario: 'before' run against a contradicting not 'beforeOrAt' should only only generate string, numeric and null
      Given foo is before 2019-01-01T00:00:00.000
        And foo is anything but before or at 2019-01-02T00:00:00.000

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
@@ -1,0 +1,162 @@
+package com.scottlogic.deg.generator.fieldspecs;
+
+import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
+import com.scottlogic.deg.generator.restrictions.DataTypeRestrictions;
+import com.scottlogic.deg.generator.restrictions.DateTimeRestrictions;
+import com.scottlogic.deg.generator.restrictions.DateTimeRestrictionsMerger;
+import com.scottlogic.deg.generator.restrictions.MergeResult;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DateTimeRestrictionsMergeOperationTests {
+    @Test
+    public void applyMergeOperation_withNoDateTimeRestrictions_shouldNotApplyAnyRestrictions(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty;
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>(null));
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), sameInstance(merging));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndNoTypeRestrictions_shouldPreventAnyTemporalValues(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty;
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getDateTimeRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.TEMPORAL)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryDateTimeRestrictions_shouldPreventAnyTemporalValues(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING, IsOfTypeConstraint.Types.TEMPORAL),
+                FieldSpecSource.Empty);
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getDateTimeRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.TEMPORAL)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndTemporalTypeAlreadyNotPermitted_shouldPreventAnyTemporalValues(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getDateTimeRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.TEMPORAL)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndTemporalTypeOnlyPermittedType_shouldPreventAnyTemporalValues(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.TEMPORAL), FieldSpecSource.Empty);
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getDateTimeRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), empty());
+    }
+
+    @Test
+    public void applyMergeOperation_withMergableDateTimeRestrictions_shouldApplyMergedDateTimeRestrictions(){
+        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
+        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.TEMPORAL), FieldSpecSource.Empty);
+        DateTimeRestrictions merged = new DateTimeRestrictions();
+        when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
+            .thenReturn(new MergeResult<>(merged));
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getDateTimeRestrictions(), sameInstance(merged));
+        Assert.assertThat(result.get().getTypeRestrictions(), sameInstance(merging.getTypeRestrictions()));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/DateTimeRestrictionsMergeOperationTests.java
@@ -6,6 +6,7 @@ import com.scottlogic.deg.generator.restrictions.DateTimeRestrictions;
 import com.scottlogic.deg.generator.restrictions.DateTimeRestrictionsMerger;
 import com.scottlogic.deg.generator.restrictions.MergeResult;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -20,16 +21,26 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DateTimeRestrictionsMergeOperationTests {
+    private DateTimeRestrictionsMerger merger;
+    private DateTimeRestrictionsMergeOperation operation;
+    private FieldSpec left;
+    private FieldSpec right;
+
+    @BeforeEach
+    public void beforeEach(){
+        merger = mock(DateTimeRestrictionsMerger.class);
+        operation = new DateTimeRestrictionsMergeOperation(merger);
+
+        left = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+        right = FieldSpec.Empty.withDateTimeRestrictions(
+            new DateTimeRestrictions(),
+            FieldSpecSource.Empty);
+    }
+
     @Test
     public void applyMergeOperation_withNoDateTimeRestrictions_shouldNotApplyAnyRestrictions(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty;
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(new MergeResult<>(null));
@@ -42,14 +53,6 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndNoTypeRestrictions_shouldPreventAnyTemporalValues(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty;
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
             .thenReturn(new MergeResult<>());
@@ -65,14 +68,6 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictions_shouldPreventAnyTemporalValues(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING, IsOfTypeConstraint.Types.TEMPORAL),
                 FieldSpecSource.Empty);
@@ -90,14 +85,6 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndTemporalTypeAlreadyNotPermitted_shouldPreventAnyTemporalValues(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
@@ -114,14 +101,6 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryDateTimeRestrictionsAndTemporalTypeOnlyPermittedType_shouldPreventAnyTemporalValues(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.TEMPORAL), FieldSpecSource.Empty);
         when(merger.merge(left.getDateTimeRestrictions(), right.getDateTimeRestrictions()))
@@ -138,14 +117,6 @@ class DateTimeRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withMergableDateTimeRestrictions_shouldApplyMergedDateTimeRestrictions(){
-        DateTimeRestrictionsMerger merger = mock(DateTimeRestrictionsMerger.class);
-        DateTimeRestrictionsMergeOperation operation = new DateTimeRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withDateTimeRestrictions(
-            new DateTimeRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.TEMPORAL), FieldSpecSource.Empty);
         DateTimeRestrictions merged = new DateTimeRestrictions();

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -6,6 +6,7 @@ import com.scottlogic.deg.generator.restrictions.MergeResult;
 import com.scottlogic.deg.generator.restrictions.NumericRestrictions;
 import com.scottlogic.deg.generator.restrictions.NumericRestrictionsMerger;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -20,16 +21,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class NumericRestrictionsMergeOperationTests {
+    private NumericRestrictionsMerger merger;
+    private NumericRestrictionsMergeOperation operation;
+    private FieldSpec left;
+    private FieldSpec right;
+
+    @BeforeEach
+    public void beforeEach(){
+        merger = mock(NumericRestrictionsMerger.class);
+        operation = new NumericRestrictionsMergeOperation(merger);
+        left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+    }
+
     @Test
     public void applyMergeOperation_withNoNumericRestrictions_shouldNotApplyAnyRestriction(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty;
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(new MergeResult<>(null));
@@ -42,14 +52,6 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNoTypeRestrictions_shouldPreventAnyNumericValues(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty;
         when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
             .thenReturn(new MergeResult<>());
@@ -65,14 +67,6 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictions_shouldPreventAnyNumericValues(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING, IsOfTypeConstraint.Types.NUMERIC),
                 FieldSpecSource.Empty);
@@ -91,14 +85,6 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeAlreadyNotPermitted_shouldPreventAnyNumericValues(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING), FieldSpecSource.Empty);
 
@@ -116,14 +102,6 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeOnlyPermittedType_shouldPreventAnyNumericValues(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
 
@@ -141,14 +119,6 @@ class NumericRestrictionsMergeOperationTests {
 
     @Test
     public void applyMergeOperation_withMergableNumericRestrictions_shouldApplyMergedNumericRestrictions(){
-        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
-        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
-        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
-        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
-            new NumericRestrictions(),
-            FieldSpecSource.Empty);
         FieldSpec merging = FieldSpec.Empty
             .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
         NumericRestrictions merged = new NumericRestrictions();

--- a/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/fieldspecs/NumericRestrictionsMergeOperationTests.java
@@ -1,0 +1,165 @@
+package com.scottlogic.deg.generator.fieldspecs;
+
+import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
+import com.scottlogic.deg.generator.restrictions.DataTypeRestrictions;
+import com.scottlogic.deg.generator.restrictions.MergeResult;
+import com.scottlogic.deg.generator.restrictions.NumericRestrictions;
+import com.scottlogic.deg.generator.restrictions.NumericRestrictionsMerger;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NumericRestrictionsMergeOperationTests {
+    @Test
+    public void applyMergeOperation_withNoNumericRestrictions_shouldNotApplyAnyRestriction(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty;
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>(null));
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), sameInstance(merging));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryNumericRestrictionsAndNoTypeRestrictions_shouldPreventAnyNumericValues(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty;
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getNumericRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.NUMERIC)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryNumericRestrictions_shouldPreventAnyNumericValues(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING, IsOfTypeConstraint.Types.NUMERIC),
+                FieldSpecSource.Empty);
+
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getNumericRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.NUMERIC)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeAlreadyNotPermitted_shouldPreventAnyNumericValues(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.STRING), FieldSpecSource.Empty);
+
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getNumericRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), not(hasItem(IsOfTypeConstraint.Types.NUMERIC)));
+    }
+
+    @Test
+    public void applyMergeOperation_withContradictoryNumericRestrictionsAndNumericTypeOnlyPermittedType_shouldPreventAnyNumericValues(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
+
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>());
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getNumericRestrictions(), is(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions(), not(nullValue()));
+        Assert.assertThat(result.get().getTypeRestrictions().getAllowedTypes(), empty());
+    }
+
+    @Test
+    public void applyMergeOperation_withMergableNumericRestrictions_shouldApplyMergedNumericRestrictions(){
+        NumericRestrictionsMerger merger = mock(NumericRestrictionsMerger.class);
+        NumericRestrictionsMergeOperation operation = new NumericRestrictionsMergeOperation(merger);
+        FieldSpec left = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec right = FieldSpec.Empty.withNumericRestrictions(
+            new NumericRestrictions(),
+            FieldSpecSource.Empty);
+        FieldSpec merging = FieldSpec.Empty
+            .withTypeRestrictions(DataTypeRestrictions.createFromWhiteList(IsOfTypeConstraint.Types.NUMERIC), FieldSpecSource.Empty);
+        NumericRestrictions merged = new NumericRestrictions();
+        when(merger.merge(left.getNumericRestrictions(), right.getNumericRestrictions()))
+            .thenReturn(new MergeResult<>(merged));
+
+        Optional<FieldSpec> result = operation.applyMergeOperation(left, right, merging);
+
+        Assert.assertThat(result.isPresent(), is(true));
+        Assert.assertThat(result.get(), not(sameInstance(merging)));
+        Assert.assertThat(result.get().getNumericRestrictions(), sameInstance(merged));
+        Assert.assertThat(result.get().getTypeRestrictions(), sameInstance(merging.getTypeRestrictions()));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictionsTests.java
@@ -1,0 +1,56 @@
+package com.scottlogic.deg.generator.restrictions;
+
+import com.scottlogic.deg.generator.constraints.atomic.IsOfTypeConstraint;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataTypeRestrictionsTests {
+    @Test
+    public void except_withAlreadyExcludedType_shouldReturnSameCollectionOfPermittedTypes(){
+        TypeRestrictions exceptStrings = DataTypeRestrictions.createFromWhiteList(
+            IsOfTypeConstraint.Types.NUMERIC,
+            IsOfTypeConstraint.Types.TEMPORAL);
+
+        TypeRestrictions result = exceptStrings.except(IsOfTypeConstraint.Types.STRING);
+
+        Assert.assertThat(result.getAllowedTypes(), containsInAnyOrder(
+            IsOfTypeConstraint.Types.NUMERIC,
+            IsOfTypeConstraint.Types.TEMPORAL));
+    }
+
+    @Test
+    public void except_withNoTypes_shouldReturnSameCollectionOfPermittedTypes(){
+        TypeRestrictions exceptStrings = DataTypeRestrictions.createFromWhiteList(
+            IsOfTypeConstraint.Types.NUMERIC,
+            IsOfTypeConstraint.Types.TEMPORAL);
+
+        TypeRestrictions result = exceptStrings.except();
+
+        Assert.assertThat(result, sameInstance(exceptStrings));
+    }
+
+    @Test
+    public void except_withPermittedType_shouldReturnSameCollectionExcludingGivenType(){
+        TypeRestrictions exceptStrings = DataTypeRestrictions.createFromWhiteList(
+            IsOfTypeConstraint.Types.NUMERIC,
+            IsOfTypeConstraint.Types.TEMPORAL);
+
+        TypeRestrictions result = exceptStrings.except(IsOfTypeConstraint.Types.NUMERIC);
+
+        Assert.assertThat(result.getAllowedTypes(), containsInAnyOrder(
+            IsOfTypeConstraint.Types.TEMPORAL));
+    }
+
+    @Test
+    public void except_withLastPermittedType_shouldReturnNoTypesPermitted(){
+        TypeRestrictions exceptStrings = DataTypeRestrictions.createFromWhiteList(
+            IsOfTypeConstraint.Types.TEMPORAL);
+
+        TypeRestrictions result = exceptStrings.except(IsOfTypeConstraint.Types.TEMPORAL);
+
+        Assert.assertThat(result.getAllowedTypes(), empty());
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
@@ -5,14 +5,22 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+
 class DateTimeRestrictionsMergerTests {
     @Test
     void merge_dateTimeRestrictionsAreBothNull_returnsNull() {
         DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
 
-        DateTimeRestrictions result = merger.merge(null, null);
+        MergeResult<DateTimeRestrictions> result = merger.merge(null, null);
 
-        Assert.assertNull(result);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, is(nullValue()));
     }
 
     @Test
@@ -20,9 +28,11 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
         DateTimeRestrictions right = new DateTimeRestrictions();
 
-        DateTimeRestrictions result = merger.merge(null, right);
+        MergeResult<DateTimeRestrictions> result = merger.merge(null, right);
 
-        Assert.assertSame(right, result);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, sameInstance(right));
     }
 
     @Test
@@ -30,9 +40,11 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
         DateTimeRestrictions left = new DateTimeRestrictions();
 
-        DateTimeRestrictions result = merger.merge(left, null);
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, null);
 
-        Assert.assertSame(left, result);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, sameInstance(left));
     }
 
     @Test
@@ -48,10 +60,12 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictions left = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
         DateTimeRestrictions right = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
 
-        DateTimeRestrictions result = merger.merge(left, right);
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
 
-        Assert.assertEquals(minDateTimeLimit, result.min);
-        Assert.assertEquals(maxDateTimeLimit, result.max);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions.min, equalTo(minDateTimeLimit));
+        Assert.assertThat(result.restrictions.max, equalTo(maxDateTimeLimit));
     }
 
     @Test
@@ -67,10 +81,12 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
         DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
 
-        DateTimeRestrictions result = merger.merge(left, right);
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
 
-        Assert.assertEquals(minDateTimeLimit, result.min);
-        Assert.assertEquals(maxDateTimeLimit, result.max);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions.min, equalTo(minDateTimeLimit));
+        Assert.assertThat(result.restrictions.max, equalTo(maxDateTimeLimit));
     }
 
     @Test
@@ -86,9 +102,10 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictions left = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
         DateTimeRestrictions right = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
 
-        DateTimeRestrictions result = merger.merge(left, right);
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
 
-        Assert.assertNull(result);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
     }
 
     @Test
@@ -104,8 +121,9 @@ class DateTimeRestrictionsMergerTests {
         DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
         DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
 
-        DateTimeRestrictions result = merger.merge(left, right);
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
 
-        Assert.assertNull(result);
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
@@ -1,0 +1,86 @@
+package com.scottlogic.deg.generator.restrictions;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+
+class NumericRestrictionsMergerTests {
+    @Test
+    public void merge_withNoRestrictions_shouldReturnSuccessWithNoRestrictions(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+
+        MergeResult<NumericRestrictions> result = merger.merge(null, null);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, is(nullValue()));
+    }
+
+    @Test
+    public void merge_withOnlyLeftNumericRestrictions_shouldReturnLeftRestrictions(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+        NumericRestrictions left = new NumericRestrictions();
+
+        MergeResult<NumericRestrictions> result = merger.merge(left, null);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, is(sameInstance(left)));
+    }
+
+    @Test
+    public void merge_withOnlyRightNumericRestrictions_shouldReturnLeftRestrictions(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+        NumericRestrictions right = new NumericRestrictions();
+
+        MergeResult<NumericRestrictions> result = merger.merge(null, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, is(sameInstance(right)));
+    }
+
+    @Test
+    public void merge_withNonContradictoryNumericRestrictions_shouldReturnMergedRestrictions(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+        NumericRestrictions left = new NumericRestrictions();
+        NumericRestrictions right = new NumericRestrictions();
+        left.min = new NumericLimit<>(BigDecimal.ZERO, true);
+        left.max = new NumericLimit<>(BigDecimal.TEN, true);
+        right.min = new NumericLimit<>(BigDecimal.ONE, false);
+        right.max = new NumericLimit<>(BigDecimal.TEN, false);
+
+        MergeResult<NumericRestrictions> result = merger.merge(left, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, not(nullValue()));
+        Assert.assertThat(result.restrictions.min.getLimit(), is(equalTo(BigDecimal.ONE)));
+        Assert.assertThat(result.restrictions.min.isInclusive(), is(false));
+        Assert.assertThat(result.restrictions.max.getLimit(), is(equalTo(BigDecimal.TEN)));
+        Assert.assertThat(result.restrictions.max.isInclusive(), is(false));
+    }
+
+    @Test
+    public void merge_withContradictoryNumericRestrictions_shouldReturnUnsuccessful(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+        NumericRestrictions left = new NumericRestrictions();
+        NumericRestrictions right = new NumericRestrictions();
+        left.min = new NumericLimit<>(BigDecimal.ZERO, true);
+        left.max = new NumericLimit<>(BigDecimal.TEN, true);
+        right.min = new NumericLimit<>(BigDecimal.TEN, false);
+        right.max = new NumericLimit<>(BigDecimal.valueOf(20), false);
+
+        MergeResult<NumericRestrictions> result = merger.merge(left, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/NumericRestrictionsMergerTests.java
@@ -69,6 +69,25 @@ class NumericRestrictionsMergerTests {
     }
 
     @Test
+    public void merge_withLessThanOrEqualAndGreaterThanOrEqualSameNumber_shouldReturnMergedRestrictions(){
+        NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
+        NumericRestrictions greaterThanOrEqual = new NumericRestrictions();
+        NumericRestrictions lessThanOrEqual = new NumericRestrictions();
+        greaterThanOrEqual.min = new NumericLimit<>(BigDecimal.TEN, true);
+        lessThanOrEqual.max = new NumericLimit<>(BigDecimal.TEN, true);
+
+        MergeResult<NumericRestrictions> result = merger.merge(greaterThanOrEqual, lessThanOrEqual);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(true));
+        Assert.assertThat(result.restrictions, not(nullValue()));
+        Assert.assertThat(result.restrictions.min.getLimit(), is(equalTo(BigDecimal.TEN)));
+        Assert.assertThat(result.restrictions.min.isInclusive(), is(true));
+        Assert.assertThat(result.restrictions.max.getLimit(), is(equalTo(BigDecimal.TEN)));
+        Assert.assertThat(result.restrictions.max.isInclusive(), is(true));
+    }
+
+    @Test
     public void merge_withContradictoryNumericRestrictions_shouldReturnUnsuccessful(){
         NumericRestrictionsMerger merger = new NumericRestrictionsMerger();
         NumericRestrictions left = new NumericRestrictions();


### PR DESCRIPTION
### Description
DateTime restriction merging would permit all temporal values if contradicting restrictions were found.
When checking the above, it was found that Numeric restrictions did not check for contradictions, this has been aligned to mirror the changes for DateTime merging.

### Changes
- If a DateTime range contradiction is found, prevent any production of temporal values
- Check for contradictions with numeric ranges
- If a Numeric range contradiction is found, prevent any production of string values
- Introduction of tests for both DateTime and Numeric mergers and their merge-operations
- Scenario where bug was identified un-ignored in Before.feature

All tests run and pass in 12.8s-13.8s (3 runs) - as at 08/03/2019

### Issue
Resolves #635 
Resolves #673