### PR TITLE
715- fixes for smoke tests over example profiles

### DIFF
--- a/examples/a-valid-isin/profile.json
+++ b/examples/a-valid-isin/profile.json
@@ -4,6 +4,10 @@
         { "name": "isin" }
     ],
     "rules": [
-		{ "field": "isin", "is": "aValid", "value": "ISIN" }
+		{ "constraints": 
+			[
+				{ "field": "isin", "is": "aValid", "value": "ISIN" }
+			] 
+		}
 	]
 }

--- a/examples/actor-names/profile.json
+++ b/examples/actor-names/profile.json
@@ -5,16 +5,20 @@
 		{ "name": "surname" }
 	],
 	"rules": [
-		{
-			"anyOf": [
-				{ "field": "forename", "is": "equalTo", "value": "Matt" },
-				{ "field": "forename", "is": "equalTo", "value": "Ryan" }
+		{ 
+			"constraints": [
+				{
+					"anyOf": [
+						{ "field": "forename", "is": "equalTo", "value": "Matt" },
+						{ "field": "forename", "is": "equalTo", "value": "Ryan" }
+					]
+				},
+				{
+					"if": { "field": "forename", "is": "equalTo", "value": "Matt" },
+					"then": { "field": "surname", "is": "equalTo", "value": "Damon" },
+					"else": { "field": "surname", "is": "inSet", "values": [ "Reynolds", "Gosling" ] }
+				}
 			]
-		},
-		{
-			"if": { "field": "forename", "is": "equalTo", "value": "Matt" },
-			"then": { "field": "surname", "is": "equalTo", "value": "Damon" },
-			"else": { "field": "surname", "is": "inSet", "values": [ "Reynolds", "Gosling" ] }
 		}
 	]
 }

--- a/examples/date-equal-to/profile.json
+++ b/examples/date-equal-to/profile.json
@@ -6,10 +6,12 @@
         }
     ],
     "rules": [
-        {
-			"field": "date",
-			"is": "equalTo",
-			"value": { "date": "2001-02-03T04:05:06.007" }
-        }
+		{ "constraints": [
+			{
+				"field": "date",
+				"is": "equalTo",
+				"value": { "date": "2001-02-03T04:05:06.007" }
+			}
+		] }
     ]
 }

--- a/examples/duplicates/profile.json
+++ b/examples/duplicates/profile.json
@@ -4,10 +4,12 @@
         { "name": "a" }
     ],
     "rules": [
-		{ "not": { "field": "a", "is": "null" } },
-		{ "anyOf": [
-			{ "field": "a", "is": "equalTo", "value": "foo" },
-			{ "field": "a", "is": "equalTo", "value": "foo" }
-		]}
+		{ "constraints": [
+			{ "not": { "field": "a", "is": "null" } },
+			{ "anyOf": [
+				{ "field": "a", "is": "equalTo", "value": "foo" },
+				{ "field": "a", "is": "equalTo", "value": "foo" }
+			]}
+		] }
 	]
 }

--- a/examples/formatting-integer/profile.json
+++ b/examples/formatting-integer/profile.json
@@ -4,13 +4,15 @@
 		{ "name": "an_integer" }
 	],
 	"rules": [
-		{ "not": { "field": "an_integer", "is": "null" } },
+		{ "constraints": [
+			{ "not": { "field": "an_integer", "is": "null" } },
 
-		{ "field": "an_integer", "is": "ofType", "value": "numeric" },
-		{ "field": "an_integer", "is": "granularTo", "value": 1 },
+			{ "field": "an_integer", "is": "ofType", "value": "numeric" },
+			{ "field": "an_integer", "is": "granularTo", "value": 1 },
 
-		{ "field": "an_integer", "is": "equalTo", "value": 1000 },
+			{ "field": "an_integer", "is": "equalTo", "value": 1000 },
 
-		{ "field": "an_integer", "is": "formattedAs", "value": "%,d" }
+			{ "field": "an_integer", "is": "formattedAs", "value": "%,d" }
+		] }
 	]
 }

--- a/examples/integer-range-with-blacklist/profile.json
+++ b/examples/integer-range-with-blacklist/profile.json
@@ -4,13 +4,15 @@
 		{ "name": "an_integer" }
 	],
 	"rules": [
-		{ "not": { "field": "an_integer", "is": "null" } },
-		{ "field": "an_integer", "is": "ofType", "value": "numeric" },
-		{ "field": "an_integer", "is": "granularTo", "value": 1 },
+		{ "constraints": [
+			{ "not": { "field": "an_integer", "is": "null" } },
+			{ "field": "an_integer", "is": "ofType", "value": "numeric" },
+			{ "field": "an_integer", "is": "granularTo", "value": 1 },
 
-		{ "field": "an_integer", "is": "greaterThanOrEqualTo", "value": 1 },
-		{ "field": "an_integer", "is": "lessThanOrEqualTo", "value": 4 },
+			{ "field": "an_integer", "is": "greaterThanOrEqualTo", "value": 1 },
+			{ "field": "an_integer", "is": "lessThanOrEqualTo", "value": 4 },
 
-		{ "not" : { "field": "an_integer", "is": "inSet", "values": [ 1 ]} }
+			{ "not" : { "field": "an_integer", "is": "inSet", "values": [ 1 ]} }
+		] }
 	]
 }

--- a/examples/integer-range/profile.json
+++ b/examples/integer-range/profile.json
@@ -4,11 +4,13 @@
 		{ "name": "an_integer" }
 	],
 	"rules": [
-		{ "not": { "field": "an_integer", "is": "null" } },
-		{ "field": "an_integer", "is": "ofType", "value": "numeric" },
-		{ "field": "an_integer", "is": "granularTo", "value": 1 },
+		{ "constraints": [
+			{ "not": { "field": "an_integer", "is": "null" } },
+			{ "field": "an_integer", "is": "ofType", "value": "numeric" },
+			{ "field": "an_integer", "is": "granularTo", "value": 1 },
 
-		{ "field": "an_integer", "is": "greaterThanOrEqualTo", "value": 1 },
-		{ "field": "an_integer", "is": "lessThanOrEqualTo", "value": 4 }
+			{ "field": "an_integer", "is": "greaterThanOrEqualTo", "value": 1 },
+			{ "field": "an_integer", "is": "lessThanOrEqualTo", "value": 4 }
+		] }
 	]
 }

--- a/examples/partitioning/profile.json
+++ b/examples/partitioning/profile.json
@@ -12,25 +12,28 @@
 		{ "name": "p3f3" }
     ],
     "rules": [
-		{ "field": "p1f1", "is": "inSet", "values": [ "p1-null", "p1-string" ] },
+		{ "constraints": [ 
+			{ "field": "p1f1", "is": "inSet", "values": [ "p1-null", "p1-string" ] },
 
-		{
-			"if": { "field": "p1f1", "is": "equalTo", "value": "p1-null" },
-			"then": { "field": "p1f2", "is": "null" },
-			"else": { "field": "p1f2", "is": "inSet", "values": [ "hello", "goodbye" ] }
-		},
+			{
+				"if": { "field": "p1f1", "is": "equalTo", "value": "p1-null" },
+				"then": { "field": "p1f2", "is": "null" },
+				"else": { "field": "p1f2", "is": "inSet", "values": [ "hello", "goodbye" ] }
+			},
 
-		{
-			"if": { "field": "p1f1", "is": "equalTo", "value": "p1-null" },
-			"then": { "field": "p1f3", "is": "null" },
-			"else":
-			{ 
-				"anyOf": [
-					{ "field": "p1f3", "is": "equalTo", "value": "string-1" },
-					{ "field": "p1f3", "is": "equalTo", "value": "string-2" }
-				]
+			{
+				"if": { "field": "p1f1", "is": "equalTo", "value": "p1-null" },
+				"then": { "field": "p1f3", "is": "null" },
+				"else":
+				{ 
+					"anyOf": [
+						{ "field": "p1f3", "is": "equalTo", "value": "string-1" },
+						{ "field": "p1f3", "is": "equalTo", "value": "string-2" }
+					]
+				}
 			}
-		},
+		] },
+			
 
 		{
 			"rule": "partition 2 stuff",

--- a/examples/real-number-range/profile.json
+++ b/examples/real-number-range/profile.json
@@ -4,11 +4,13 @@
 		{ "name": "a_number" }
 	],
 	"rules": [
-		{ "not": { "field": "a_number", "is": "null" } },
-		{ "field": "a_number", "is": "ofType", "value": "numeric" },
-		{ "field": "a_number", "is": "granularTo", "value": 0.01 },
+		{ "constraints": [
+			{ "not": { "field": "a_number", "is": "null" } },
+			{ "field": "a_number", "is": "ofType", "value": "numeric" },
+			{ "field": "a_number", "is": "granularTo", "value": 0.01 },
 
-		{ "field": "a_number", "is": "greaterThanOrEqualTo", "value": 1 },
-		{ "field": "a_number", "is": "lessThanOrEqualTo", "value": 4 }
+			{ "field": "a_number", "is": "greaterThanOrEqualTo", "value": 1 },
+			{ "field": "a_number", "is": "lessThanOrEqualTo", "value": 4 }
+		] }
 	]
 }

--- a/examples/regex-contains/profile.json
+++ b/examples/regex-contains/profile.json
@@ -4,7 +4,9 @@
 		{ "name": "first_name" }
     ],
     "rules": [
-		{ "not": { "field": "first_name", "is": "null" } },
-		{ "field": "first_name", "is": "containingRegex", "value": "^(Joh?n|Mar[yk])$" }
+		{ "constraints": [
+			{ "not": { "field": "first_name", "is": "null" } },
+			{ "field": "first_name", "is": "containingRegex", "value": "^(Joh?n|Mar[yk])$" }
+		] }
 	]
 }

--- a/examples/regex-intersect-with-blacklist/profile.json
+++ b/examples/regex-intersect-with-blacklist/profile.json
@@ -6,9 +6,11 @@
 		}
 	],
 	"rules": [
-		{ "not": { "field": "first_name", "is": "null" } },
-		{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" },
-		{ "field": "first_name", "is": "matchingRegex", "value": "M.*" },
-		{ "not": { "field": "first_name", "is": "equalTo", "value": "Mary" } }
+		{ "constraints": [
+			{ "not": { "field": "first_name", "is": "null" } },
+			{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" },
+			{ "field": "first_name", "is": "matchingRegex", "value": "M.*" },
+			{ "not": { "field": "first_name", "is": "equalTo", "value": "Mary" } }
+		] }
 	]
 }

--- a/examples/regex-intersect/profile.json
+++ b/examples/regex-intersect/profile.json
@@ -4,8 +4,10 @@
 		{ "name": "first_name" }
     ],
     "rules": [
-		{ "not": { "field": "first_name", "is": "null" } },
-		{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" },
-		{ "field": "first_name", "is": "matchingRegex", "value": "M.*" }
+		{ "constraints": [
+			{ "not": { "field": "first_name", "is": "null" } },
+			{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" },
+			{ "field": "first_name", "is": "matchingRegex", "value": "M.*" }
+		] }
 	]
 }

--- a/examples/regex/profile.json
+++ b/examples/regex/profile.json
@@ -4,7 +4,9 @@
 		{ "name": "first_name" }
     ],
     "rules": [
-		{ "not": { "field": "first_name", "is": "null" } },
-		{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" }
+		{ "constraints": [
+			{ "not": { "field": "first_name", "is": "null" } },
+			{ "field": "first_name", "is": "matchingRegex", "value": "(Joh?n|Mar[yk])" }
+		] }
 	]
 }

--- a/examples/setwise-combination/profile.json
+++ b/examples/setwise-combination/profile.json
@@ -5,10 +5,12 @@
 		{ "name": "b" }
     ],
     "rules": [
-		{ "not": { "field": "a", "is": "null" } },
-		{ "field": "a", "is": "inSet", "values": [ "X", "Y", "Z" ] },
-		
-		{ "not": { "field": "b", "is": "null" } },
-		{ "field": "b", "is": "inSet", "values": [ "1", "2" ] }
+		{ "constraints": [
+			{ "not": { "field": "a", "is": "null" } },
+			{ "field": "a", "is": "inSet", "values": [ "X", "Y", "Z" ] },
+			
+			{ "not": { "field": "b", "is": "null" } },
+			{ "field": "b", "is": "inSet", "values": [ "1", "2" ] }
+		] }
 	]
 }

--- a/examples/shorter-than/profile.json
+++ b/examples/shorter-than/profile.json
@@ -4,7 +4,9 @@
 		{ "name": "first_name" }
     ],
     "rules": [
-		{ "not": { "field": "first_name", "is": "null" } },
-		{ "field": "first_name", "is": "shorterThan", "value": 200 }
+		{ "constraints": [
+			{ "not": { "field": "first_name", "is": "null" } },
+			{ "field": "first_name", "is": "shorterThan", "value": 200 }
+		] }
 	]
 }

--- a/examples/type-exclusion/profile.json
+++ b/examples/type-exclusion/profile.json
@@ -4,6 +4,8 @@
 		{ "name": "not_number" }
 	],
 	"rules": [
-		{ "not": { "field": "not_number", "is": "ofType", "value": "numeric" } }
+		{ "constraints": [
+			{ "not": { "field": "not_number", "is": "ofType", "value": "numeric" } }
+		] }
 	]
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
@@ -10,13 +10,13 @@ import com.scottlogic.deg.generator.decisiontree.treepartitioning.RelatedFieldTr
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecFactory;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpecMerger;
 import com.scottlogic.deg.generator.fieldspecs.RowSpecMerger;
+import com.scottlogic.deg.generator.generation.*;
+import com.scottlogic.deg.generator.generation.databags.StandardRowSpecDataBagSourceFactory;
 import com.scottlogic.deg.generator.inputs.InvalidProfileException;
 import com.scottlogic.deg.generator.inputs.JsonProfileReader;
 import com.scottlogic.deg.generator.inputs.profileviolation.IndividualConstraintRuleViolator;
 import com.scottlogic.deg.generator.inputs.profileviolation.IndividualRuleProfileViolator;
 import com.scottlogic.deg.generator.inputs.validation.NoopProfileValidator;
-import com.scottlogic.deg.generator.generation.*;
-import com.scottlogic.deg.generator.generation.databags.StandardRowSpecDataBagSourceFactory;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.outputs.datasetwriters.DataSetWriter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
@@ -49,9 +49,9 @@ class ExampleProfilesViolationTests {
                 GenerationConfig.TreeWalkerType.CARTESIAN_PRODUCT,
                 GenerationConfig.CombinationStrategyType.PINNING));
                 
-        return forEachProfileFile(config, ((generationEngine, profileFile) -> {
+        return forEachProfileFile(config, ((standard, violating, profileFile) -> {
             final Profile profile = new JsonProfileReader(new NoopProfileValidator()).read(profileFile.toPath());
-            generationEngine.generateDataSet(profile, config, new NullOutputTarget());
+            standard.generateDataSet(profile, config, new NullOutputTarget());
         }));
     }
 
@@ -63,9 +63,9 @@ class ExampleProfilesViolationTests {
                 GenerationConfig.TreeWalkerType.CARTESIAN_PRODUCT,
                 GenerationConfig.CombinationStrategyType.PINNING));
 
-        return forEachProfileFile(config, ((generationEngine, profileFile) -> {
+        return forEachProfileFile(config, ((standard, violating, profileFile) -> {
             final Profile profile = new JsonProfileReader(new NoopProfileValidator()).read(profileFile.toPath());
-            generationEngine.generateDataSet(profile, config, new NullOutputTarget());
+            violating.generateDataSet(profile, config, new NullOutputTarget());
         }));
     }
 
@@ -109,6 +109,7 @@ class ExampleProfilesViolationTests {
                         engine);
 
                 consumer.generate(
+                    engine,
                     violationGenerationEngine,
                     profileFile);
             });
@@ -120,12 +121,12 @@ class ExampleProfilesViolationTests {
     }
 
     private class NullOutputTarget extends FileOutputTarget {
-        public NullOutputTarget() {
+        NullOutputTarget() {
             super(null, new NullDataSetWriter());
         }
 
         @Override
-        public void outputDataset(Stream<GeneratedObject> generatedObjects, ProfileFields profileFields) throws IOException {
+        public void outputDataset(Stream<GeneratedObject> generatedObjects, ProfileFields profileFields) {
             // iterate through the rows - assume lazy generation, so we haven't tested unless we've exhausted the iterable
 
             generatedObjects.forEach(
@@ -156,6 +157,7 @@ class ExampleProfilesViolationTests {
 
     @FunctionalInterface
     private interface GenerateConsumer {
-        void generate(ViolationGenerationEngine engine, File profileFile) throws IOException, InvalidProfileException;
+        void generate(StandardGenerationEngine standardEngine, ViolationGenerationEngine violatingEngine, File profileFile) throws IOException, InvalidProfileException;
     }
+
 }


### PR DESCRIPTION
### Description
Example files are not correctly formed, and this correctness was not asserted before. In additional all smoke tests over these files only exercised the violating generator, not the _normal_ generator.

### Changes
- Update smoke tests to test both violating and _normal_ generators (as original designed)
- Introduced checks to prove correctness of example files (i.e. every rule must have at least one constraint in the examples)

All tests run and pass in ~13.5s

### Issue
Resolves #715