### PR TITLE
695- random temporal range fix

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSource.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 public class TemporalFieldValueSource implements FieldValueSource {
 
-    public static final LocalDateTime ISO_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_000_000);
+    public static final LocalDateTime ISO_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_999_999);
     public static final LocalDateTime ISO_MIN_DATE = LocalDateTime.of(1, 1, 1, 0, 0);
 
     private final DateTimeRestrictions restrictions;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSource.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 public class TemporalFieldValueSource implements FieldValueSource {
 
-    public static final LocalDateTime ISO_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999);
+    public static final LocalDateTime ISO_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999_000_000);
     public static final LocalDateTime ISO_MIN_DATE = LocalDateTime.of(1, 1, 1, 0, 0);
 
     private final DateTimeRestrictions restrictions;
@@ -124,12 +124,12 @@ public class TemporalFieldValueSource implements FieldValueSource {
 
         LocalDateTime lower = inclusiveLower != null
                 ? inclusiveLower
-                : LocalDateTime.of(1900, 01, 01, 0, 0);
+                : ISO_MIN_DATE;
 
 
         LocalDateTime upper = exclusiveUpper != null
                 ? exclusiveUpper
-                : LocalDateTime.of(2100, 01, 01, 0, 0);
+                : ISO_MAX_DATE.plusNanos(1_000_000);
 
 
         return () -> new UpCastingIterator<>(

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
@@ -45,7 +45,7 @@ public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator {
     }
 
     @Override
-    public double nextDouble(double lower, double upper) {
-        return random.nextDouble() * (upper - lower) + lower;
+    public double nextDouble(double lowerInclusive, double upperExclusive) {
+        return random.nextDouble() * (upperExclusive - lowerInclusive) + lowerInclusive;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
@@ -4,5 +4,5 @@ public interface RandomNumberGenerator {
     int nextInt();
     int nextInt(int bound);
     int nextInt(int lowerInclusive, int upperExclusive);
-    double nextDouble(double lower, double upper);
+    double nextDouble(double lowerInclusive, double upperExclusive);
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSourceTests.java
@@ -113,7 +113,7 @@ public class TemporalFieldValueSourceTests {
 
 
     @Test
-    public void whenGeneratingRandomValues() {
+    public void getRandomValues_withExclusiveUpperBound_shouldGenerateCorrectValues() {
         LocalDate date = LocalDate.of(2018, 1, 10);
         givenLowerBound(LocalDateTime.of(date, LocalTime.of(12, 0, 0)), true);
         givenUpperBound(LocalDateTime.of(date, LocalTime.of(18, 0, 0)), false);
@@ -130,7 +130,7 @@ public class TemporalFieldValueSourceTests {
         Iterator<Object> iterator = fieldSource.generateRandomValues(rng).iterator();
 
         Assert.assertThat(iterator.next(),
-                equalTo(LocalDateTime.of(date, LocalTime.of(12, 0, 0))));
+            equalTo(LocalDateTime.of(date, LocalTime.of(12, 0, 0))));
 
         rng.setNextDouble(1);
 
@@ -139,15 +139,120 @@ public class TemporalFieldValueSourceTests {
         iterator = fieldSource.generateRandomValues(rng).iterator();
 
         Assert.assertThat(iterator.next(),
-                equalTo(LocalDateTime.of(date, LocalTime.of(17, 59, 59, 999_000_000))));
+            equalTo(LocalDateTime.of(date, LocalTime.of(17, 59, 59, 999_000_000))));
 
         rng.setNextDouble(0.5);
 
         iterator = fieldSource.generateRandomValues(rng).iterator();
 
         Assert.assertThat(iterator.next(),
-                equalTo(LocalDateTime.of(date, LocalTime.of(14, 59, 59, 999_000_000))));
+            equalTo(LocalDateTime.of(date, LocalTime.of(14, 59, 59, 999_000_000))));
 
+    }
+
+    @Test
+    public void getRandomValues_withInclusiveUpperBound_shouldGenerateCorrectValues() {
+        LocalDate date = LocalDate.of(2018, 1, 10);
+        givenLowerBound(LocalDateTime.of(date, LocalTime.of(12, 0, 0)), true);
+        givenUpperBound(LocalDateTime.of(date, LocalTime.of(18, 0, 0)), true);
+
+        DateTimeRestrictions restrictions = new DateTimeRestrictions();
+        restrictions.min = lowerLimit;
+        restrictions.max = upperLimit;
+
+        fieldSource = new TemporalFieldValueSource(restrictions, blackList);
+
+        TestRandomNumberGenerator rng = new TestRandomNumberGenerator();
+        rng.setNextDouble(0);
+
+        Iterator<Object> iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(12, 0, 0))));
+
+        rng.setNextDouble(1);
+
+        // Because internally the filteringIterator pre-generates the first value before we can set
+        // the new "random" value we have re-create the iterator
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(18, 0, 0))));
+
+        rng.setNextDouble(0.5);
+
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(15, 0, 0))));
+    }
+
+    @Test
+    public void getRandomValues_withExclusiveLowerBound_shouldGenerateCorrectValues() {
+        LocalDate date = LocalDate.of(2018, 1, 10);
+        givenLowerBound(LocalDateTime.of(date, LocalTime.of(12, 0, 0)), false);
+        givenUpperBound(LocalDateTime.of(date, LocalTime.of(18, 0, 0)), true);
+
+        DateTimeRestrictions restrictions = new DateTimeRestrictions();
+        restrictions.min = lowerLimit;
+        restrictions.max = upperLimit;
+
+        fieldSource = new TemporalFieldValueSource(restrictions, blackList);
+
+        TestRandomNumberGenerator rng = new TestRandomNumberGenerator();
+        rng.setNextDouble(0);
+
+        Iterator<Object> iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(12, 0, 0, 1_000_000))));
+
+        rng.setNextDouble(1);
+
+        // Because internally the filteringIterator pre-generates the first value before we can set
+        // the new "random" value we have re-create the iterator
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(18, 0, 0))));
+
+        rng.setNextDouble(0.5);
+
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(15, 0, 0))));
+    }
+
+    @Test
+    public void getRandomValues_withNoExplicitBounds_shouldGenerateCorrectValues() {
+        DateTimeRestrictions restrictions = new DateTimeRestrictions();
+
+        fieldSource = new TemporalFieldValueSource(restrictions, blackList);
+
+        TestRandomNumberGenerator rng = new TestRandomNumberGenerator();
+        rng.setNextDouble(0);
+
+        Iterator<Object> iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(TemporalFieldValueSource.ISO_MIN_DATE));
+
+        rng.setNextDouble(1);
+
+        // Because internally the filteringIterator pre-generates the first value before we can set
+        // the new "random" value we have re-create the iterator
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(TemporalFieldValueSource.ISO_MAX_DATE));
+
+        rng.setNextDouble(0.5);
+
+        iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(5000, 07, 02, 11, 59, 59, 999_000_000)));
     }
 
     @Test

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/TemporalFieldValueSourceTests.java
@@ -225,6 +225,26 @@ public class TemporalFieldValueSourceTests {
     }
 
     @Test
+    public void getRandomValues_withSmallPermittedRangeAtEndOfLegalRange_shouldGenerateCorrectValues() {
+        LocalDate date = LocalDate.of(9999, 12, 31);
+        givenLowerBound(LocalDateTime.of(date, LocalTime.of(23, 0, 0)), false);
+
+        DateTimeRestrictions restrictions = new DateTimeRestrictions();
+        restrictions.min = lowerLimit;
+        restrictions.max = upperLimit;
+
+        fieldSource = new TemporalFieldValueSource(restrictions, blackList);
+
+        TestRandomNumberGenerator rng = new TestRandomNumberGenerator();
+        rng.setNextDouble(0.99);
+
+        Iterator<Object> iterator = fieldSource.generateRandomValues(rng).iterator();
+
+        Assert.assertThat(iterator.next(),
+            equalTo(LocalDateTime.of(date, LocalTime.of(23, 59, 23, 999_000_000))));
+    }
+
+    @Test
     public void getRandomValues_withNoExplicitBounds_shouldGenerateCorrectValues() {
         DateTimeRestrictions restrictions = new DateTimeRestrictions();
 


### PR DESCRIPTION
### Description
Temporal values are emitted in a small range when random mode is enabled, this fix unifies the ranges to the document (if #636) range.

### Changes
- Set production of random values to produce between _0001-01-01T00:00:00_ and _9999-12-31T23:59:59.999_ **inclusively**
- Introduced tests for change of behaviour, extended existing tests for additionally considered scenarios
- Fixed max range to be 999,000,000 nanoseconds (i.e. 999 milliseconds), rather than 999 nanoseconds
- Implementation detail: Updated random interface to clarify that decimal bounds are inclusive and exclusive as appropriate.

### Additional notes
No cucumber scenarios exist for random at present, but will be covered in #719 and #720.

All tests run and pass in 11.635s

### Issue
Resolves #695