### PR TITLE
#686 dedupe shorter than ci

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ContainingRegex.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ContainingRegex.feature
@@ -175,7 +175,7 @@ Scenario: Running a 'containingRegex' request that includes anchors ^ and $ shou
        | "c"  |
 
 
-Scenario: Running a 'containingRegex' request that includes only anchor ^ should be successful
+Scenario: containingRegex that does not include the closing anchor '$' should be successful
      Given there is a field foo
        And foo is containing regex /^[a-c]{1}/
        And foo is of length 1
@@ -186,7 +186,7 @@ Scenario: Running a 'containingRegex' request that includes only anchor ^ should
        | "b"  |
        | "c"  |
 
-Scenario: Running a 'containingRegex' request that includes only anchor $ should be successful
+Scenario: containingRegex that does not include the opening anchor '^' should be successful
      Given there is a field foo
        And foo is containing regex /[a-c]{1}$/
        And foo is of length 1

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/ShorterThan.feature
@@ -2,8 +2,8 @@ Feature: User can specify that a string length is lower than, a specified number
 
 Background:
      Given the generation strategy is full
-      And there is a field foo
-      And foo is of type "string"
+       And there is a field foo
+       And foo is of type "string"
 
 Scenario: Running a 'shorterThan' request using a number to specify a the length of a generated string should be successful
      Given foo is shorter than 5
@@ -37,26 +37,6 @@ Scenario: Running a 'shorterThan' request using a string (number) to specify a t
      Then I am presented with an error message
        And no data is created
 
-Scenario: Running a 'shorterThan' request using a string (a-z character) to specify a the length of a generated string should fail with an error message
-     Given foo is shorter than "five"
-     Then I am presented with an error message
-       And no data is created
-
-Scenario: Running a 'shorterThan' request using a string (A-Z character) to specify a the length of a generated string should fail with an error message
-     Given foo is shorter than "FIVE"
-     Then I am presented with an error message
-       And no data is created
-
-Scenario: Running a 'shorterThan' request using a string (A-Z character) to specify a the length of a generated string should fail with an error message
-     Given foo is shorter than "FIVE"
-     Then I am presented with an error message
-       And no data is created
-
-Scenario: Running a 'shorterThan' request using a string (special character) to specify a the length of a generated string should fail with an error message
-     Given foo is shorter than "!"
-     Then I am presented with an error message
-       And no data is created
-
 Scenario: Running a 'shorterThan' request using an empty string "" to specify a the length of a generated string field should fail with an error message
      Given foo is shorter than ""
      Then I am presented with an error message
@@ -67,159 +47,202 @@ Scenario: Running a 'shorterThan' request using null to specify a the length of 
      Then the profile is invalid because "Couldn't recognise 'value' property, it must be set to a value"
        And no data is created
 
-Scenario: Running a 'shorterThan' request alongside a non-contradicting inSet constraint should be successful
-     Given foo is shorter than 5
-       And foo is in set:
-       | "1234" |
-       | "123"  |
-     Then the following data should be generated:
-       | foo    |
-       | null   |
-       | "1234" |
-       | "123"  |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting inSet constraint should produce null
-     Given foo is shorter than 5
-       And foo is in set:
-       | "12345"  |
-       | "123456" |
-     Then the following data should be generated:
-       | foo    |
-       | null   |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting matchingRegex constraint should be successful
-     Given foo is shorter than 3
-       And foo is matching regex /[☠]{2}/
-     Then the following data should be generated:
-       | foo    |
-       | null   |
-       | "☠☠" |
-
-Scenario: Running a 'shorterThan' request alongside a contradicting matchingRegex constraint should generate null
-     Given foo is shorter than 2
-       And foo is matching regex /[💾]{2}/
-     Then the following data should be generated:
-       | foo    |
-       | null   |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting containingRegex constraint should be successful
-     Given foo is shorter than 3
-       And foo is containing regex /[Æ]{2}/
-       And the generator can generate at most 2 rows
-     Then the following data should be generated:
-       | foo  |
-       | null |
-       | "ÆÆ" |
-
-Scenario: Running a 'shorterThan' request alongside a contradicting containingRegex constraint should generate null
-     Given foo is shorter than 1
-       And foo is containing regex /[Ū]{2}/
-      Then the following data should be generated:
-        | foo    |
-        | null   |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting ofLength constraint should be successful
-     Given foo is shorter than 3
-       And foo is of length 2
-       And foo is matching regex /[♀]{0,2}/
-     Then the following data should be generated:
-       | foo  |
-       | null |
-       | "♀♀" |
-
-Scenario: Running a 'shorterThan' request alongside a contradicting ofLength (too short) constraint should produce null
-     Given foo is shorter than 3
-       And foo is of length 10
-     Then the following data should be generated:
-      | foo  |
-      | null |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting longerThan constraint should be successful
-     Given foo is shorter than 3
-       And foo is longer than 1
-       And foo is matching regex /[♀]{0,3}/
-     Then the following data should be generated:
-       | foo  |
-       | null |
-       | "♀♀" |
-
-Scenario: Running a 'shorterThan' request alongside a contradicting longerThan (too long) constraint should produce null
-     Given foo is shorter than 3
-       And foo is longer than 10
-     Then the following data should be generated:
-      | foo  |
-      | null |
-
-Scenario: Running a 'shorterThan' request alongside a non-contradicting shorterThan constraint should be successful
+Scenario: shorterThan run against a non contradicting shorterThan should be successful
      Given foo is shorter than 4
        And foo is shorter than 3
-       And foo is matching regex /[♀]{1,5}/
+       And foo is matching regex /[2]{1,5}/
      Then the following data should be generated:
        | foo  |
        | null |
-       | "♀"  |
-       | "♀♀" |
+       | "2"  |
+       | "22" |
 
-Scenario: Running a 'shorterThan' request alongside a greaterThan constraint should be successful
-     Given foo is shorter than 1
-       And foo is greater than 8
+Scenario: shorterThan run against a non contradicting not shorterThan should be successful
+     Given foo is shorter than 5
+       And foo is anything but shorter than 3
+       And foo is matching regex /[a]{1,5}/
      Then the following data should be generated:
-       | foo  |
-       | ""   |
-       | null |
+       | foo    |
+       | null   |
+       | "aaa"  |
+       | "aaaa" |
 
-Scenario: Running a 'shorterThan' request alongside a greaterThanOrEqualTo constraint should be successful
-     Given foo is shorter than 1
-       And foo is greater than or equal to 2
+Scenario: not shorterThan run against a non contradicting not shorterThan should be successful
+     Given foo is anything but shorter than 2
+       And foo is anything but shorter than 3
+       And foo is matching regex /[x]{1,5}/
      Then the following data should be generated:
-       | foo  |
-       | ""   |
-       | null |
+       | foo     |
+       | null    |
+       | "xxx"   |
+       | "xxxx"  |
+       | "xxxxx" |
 
-Scenario: Running a 'shorterThan' request alongside a lessThan constraint should be successful
-     Given foo is shorter than 1
-       And foo is less than 15
+Scenario: shorterThan run against a contradicting not shorterThan should only generate null
+     Given foo is shorter than 2
+       And foo is anything but shorter than 2
      Then the following data should be generated:
-       | foo  |
-       | ""   |
-       | null |
+       | foo     |
+       | null    |
 
-Scenario: Running a 'shorterThan' request alongside a lessThanOrEqualTo constraint should be successful
-     Given foo is shorter than 1
-       And foo is less than or equal to 19
+Scenario: shorterThan run against a non contradicting greaterThan should be successful
+     Given foo is shorter than 2
+       And foo is greater than 3
+       And foo is matching regex /[x]{1,5}/
      Then the following data should be generated:
        | foo  |
-       | ""   |
        | null |
+       | "x"  |
 
-@ignore #91 values are emitted from both constraints in the anyOf, where they should be 'unique' for the field
-Scenario: Running a 'shorterThan' request as part of a non-contradicting anyOf constraint should be successful
-     Given there is a constraint:
-       """
-       { "anyOf": [
-         { "field": "foo", "is": "shorterThan", "value": 2 },
-         { "field": "foo", "is": "shorterThan", "value": 3 }
-       ]}
-       """
-       And foo is matching regex /[%]{1,10}/
-       And the generator can generate at most 5 rows
+Scenario: shorterThan run against a non contradicting not greaterThan should be successful
+     Given foo is shorter than 2
+       And foo is anything but greater than 3
+       And foo is matching regex /[x]{1,5}/
      Then the following data should be generated:
        | foo  |
        | null |
-       | "%"  |
-       | "%%" |
+       | "x"  |
 
-Scenario: Running a 'shorterThan' request as part of a non-contradicting allOf constraint should be successful
-     Given there is a constraint:
-       """
-       { "allOf": [
-         { "field": "foo", "is": "shorterThan", "value": 3 },
-         { "field": "foo", "is": "shorterThan", "value": 2 }
-       ]}
-       """
-       And foo is matching regex /[%]{1,10}/
-       And the generator can generate at most 5 rows
+Scenario: shorterThan run against a non contradicting greaterThanOrEqualTo should be successful
+     Given foo is shorter than 2
+       And foo is greater than or equal to 3
+       And foo is matching regex /[x]{1,5}/
      Then the following data should be generated:
        | foo  |
        | null |
-       | "%"  |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not greaterThanOrEqualTo should be successful
+     Given foo is shorter than 2
+       And foo is anything but greater than or equal to 3
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting lessThan should be successful
+     Given foo is shorter than 2
+       And foo is less than 3
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not lessThan should be successful
+     Given foo is shorter than 2
+       And foo is anything but less than 3
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting lessThanOrEqualTo should be successful
+     Given foo is shorter than 2
+       And foo is less than or equal to 3
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not lessThanOrEqualTo should be successful
+     Given foo is shorter than 2
+       And foo is anything but less than or equal to 3
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting granularTo should be successful
+     Given foo is shorter than 2
+       And foo is granular to 1
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not granularTo should be successful
+     Given foo is shorter than 2
+       And foo is anything but granular to 1
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting after should be successful
+     Given foo is shorter than 2
+       And foo is after 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not after should be successful
+     Given foo is shorter than 2
+       And foo is anything but after 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting afterOrAt should be successful
+     Given foo is shorter than 2
+       And foo is after or at 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not afterOrAt should be successful
+     Given foo is shorter than 2
+       And foo is anything but after or at 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting before should be successful
+     Given foo is shorter than 2
+       And foo is before 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not before should be successful
+     Given foo is shorter than 2
+       And foo is anything but before 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting beforeOrAt should be successful
+     Given foo is shorter than 2
+       And foo is before or at 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |
+
+Scenario: shorterThan run against a non contradicting not beforeOrAt should be successful
+     Given foo is shorter than 2
+       And foo is anything but before or at 2019-01-01T00:00:00.000
+       And foo is matching regex /[x]{1,5}/
+     Then the following data should be generated:
+       | foo  |
+       | null |
+       | "x"  |


### PR DESCRIPTION
### Issue
Resolves #686 

### Description
- Restructure of shorterThan tests in line with test matrix to remove duplicates
- Standardisation of indenting in line with guidelines on wiki [https://github.com/ScottLogic/datahelix/wiki/Using-the-Cucumber-framework](url)

