### PR TITLE
714- command line changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For a guide on how the generator may be used see the [step by step instructions]
 Optional additional switches:
 * `--violate` generate data which violates the profile constraints
 * `-n 1000` limit the output to 1000 rows
-* `-t <data-generation-type>` - produce different data in different ways, see [generation types](./generator/docs/GenerationTypes.md)
 
 See [additional details here](./docs/Options/GenerateOptions.md) on the full list of switches that can be provided.
 

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -16,10 +16,6 @@ Option switches are case-sensitive, arguments are case-insensitive
    * Prevent profiles from being optimised during generation. Optimisation enables the generator to process profiles more efficiently, but adds more compute in other areas. See [Decision tree optimiser](../../generator/docs/OptimisationProcess.md) for more details.
 * `--validate-profile`
    * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details.
-* `--trace-constraints`
-   * When generating data emit a `<output path>-trace.json` file which will contain details of which rules and constraints caused the generator to emit each data point. See [Tracing Output](../../generator/docs/TracingOutput.md) for more details.
-* `--visualise-reductions`
-   * Debug mode for the generator. Turn on per-reduction visualisation of the profile decision tree. Will create a directory named `reductive-walker` under the output path for the files.
 
 By default the generator will report how much data has been generated over time, the other options are below:
 * `--verbose`

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -12,8 +12,6 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `-w <walker>` or `--walker-type <walker>`
-   * Use `<walker>` strategy for producing data. Options are: `CARTESIAN_PRODUCT`, `ROUTED`, `REDUCTIVE` (default), see [Tree walker types](../../generator/docs/TreeWalkerTypes.md) for more details.
 * `--no-partition`
    * Prevent rules from being partitioned during generation. Partitioning allows for a (unproven) performance improvement when processing larger profiles.
 * `--no-optimise`

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -10,8 +10,6 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `--no-optimise`
-   * Prevent profiles from being optimised during generation. Optimisation enables the generator to process profiles more efficiently, but adds more compute in other areas. See [Decision tree optimiser](../../generator/docs/OptimisationProcess.md) for more details.
 * `--validate-profile`
    * Validate the profile, check to see if known [contradictions](../../generator/docs/Contradictions.md) exist, see [Profile validation](../../generator/docs/ProfileValidation.md) for more details.
 

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -12,8 +12,6 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `-c <combinationType>` or `--combination-strategy <combinationType>`
-   * When producing data combine each data point using the `<combinationType>` strategy. Options are: `PINNING` (default), `EXHAUSTIVE`, `MINIMAL`, see [Combination strategies](../../generator/docs/CombinationStrategies.md) for more details.
 * `-w <walker>` or `--walker-type <walker>`
    * Use `<walker>` strategy for producing data. Options are: `CARTESIAN_PRODUCT`, `ROUTED`, `REDUCTIVE` (default), see [Tree walker types](../../generator/docs/TreeWalkerTypes.md) for more details.
 * `--no-partition`

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -7,8 +7,6 @@ Option switches are case-sensitive, arguments are case-insensitive
    * Generate data which violates profile constraints.
 * `--dont-violate` <epistemic constraints...>
    * Choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=typeOf lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints.
-* `-t <generationType>` or `--generation-type <generationType>`
-   * Emit `<generationType>` data. Options are: `INTERESTING` (default) or `RANDOM`, `FULL_SEQUENTIAL`, see [Generation types](../../generator/docs/GenerationTypes.md) for more details.
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -10,8 +10,6 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.
-* `--no-partition`
-   * Prevent rules from being partitioned during generation. Partitioning allows for a (unproven) performance improvement when processing larger profiles.
 * `--no-optimise`
    * Prevent profiles from being optimised during generation. Optimisation enables the generator to process profiles more efficiently, but adds more compute in other areas. See [Decision tree optimiser](../../generator/docs/OptimisationProcess.md) for more details.
 * `--validate-profile`

--- a/docs/Options/VisualiseOptions.md
+++ b/docs/Options/VisualiseOptions.md
@@ -5,9 +5,5 @@ Option switches are case-sensitive, arguments are case-insensitive
    * Include the given `<title>` in the visualisation. If not supplied, the description of in profile will be used, or the filename of the profile.
 * `--no-title`
    * Exclude the title from the visualisation. This setting overrides `-t`/`--title`.
-* `--no-optimise`
-   * Prevents tree optimisation during visualisation.
-* `--no-simplify`
-   * Prevents tree simplification during visualisation. Simplification is where decisions with only one option are folded into the parent.
  * `--overwrite`
     * Overwrite existing output files.

--- a/generator/docs/GenerationTypes.md
+++ b/generator/docs/GenerationTypes.md
@@ -28,7 +28,6 @@ Examples:
 
 Notes:
 - Random generation of data is infinite in its operation, therefore the `--max-rows` switch must be provided
-- Random generation can only be seen as random if partitioning is disabled, choosing random generation effectively implies `--no-partition`.
 
 ## Interesting
 See [this document](https://github.com/ScottLogic/datahelix/wiki/Interesting-data-generation) for more details on the _interesting generation mode_.

--- a/generator/docs/GenerationTypes.md
+++ b/generator/docs/GenerationTypes.md
@@ -27,7 +27,7 @@ Examples:
 | `Field 1 in set [A, B, C]` | _(A, B or C in any order, repeated as needed)_ | `null` |
 
 Notes:
-- Random generation of data is infinite in its operation, therefore the `--max-rows` switch must be provided
+- Random generation of data is infinite is limited to 1000 by default, use `--max-rows` to enable generation of more data.
 
 ## Interesting
 See [this document](https://github.com/ScottLogic/datahelix/wiki/Interesting-data-generation) for more details on the _interesting generation mode_.

--- a/generator/docs/GenerationTypes.md
+++ b/generator/docs/GenerationTypes.md
@@ -2,19 +2,8 @@
 
 The generator supports the following data generation types
 
-* Full sequential
-* Random
+* Random (_default_)
 * Interesting
-
-## Full sequential
-Generate every possible value for the given set of constraints. This mode could cause the tool to run forever unless some other conditions are applied, e.g. max number of rows.
-
-Examples:
-
-| Constraint | Emitted valid data | Emitted violating data |
-| ---- | ---- | ---- |
-| `Field 1 > 10 AND Field 1 < 20` | 11, 12, 13, 14, 15, 16, 17, 18, 19 | _(all values <= 10)_, _(all values >= 20)_ |
-| `Field 1 in set [A, B, C]` | A, B, C | `null` |
 
 ## Random
 Generate some random data that abides by the given set of constraints. It is mandatory for a maximum row limit `-n=<row limit>` to be specified otherwise the tool would attempt to run forever. This mode has the potential to repeat data points, it does not keep track of values that have already been emitted.

--- a/generator/docs/GenerationTypes.md
+++ b/generator/docs/GenerationTypes.md
@@ -16,7 +16,7 @@ Examples:
 | `Field 1 in set [A, B, C]` | _(A, B or C in any order, repeated as needed)_ | `null` |
 
 Notes:
-- Random generation of data is infinite is limited to 1000 by default, use `--max-rows` to enable generation of more data.
+- Random generation of data is infinite and is limited to 1000 by default, use `--max-rows` to enable generation of more data.
 
 ## Interesting
 See [this document](https://github.com/ScottLogic/datahelix/wiki/Interesting-data-generation) for more details on the _interesting generation mode_.

--- a/generator/src/main/java/com/scottlogic/deg/generator/App.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/App.java
@@ -6,7 +6,7 @@ import picocli.CommandLine;
 
 import java.util.stream.Collectors;
 
-@CommandLine.Command(name = "dg")
+@CommandLine.Command(name = "datahelix")
 public class App implements Runnable {
     private static final CommandLine picoCliCommandLine = new CommandLine(new App())
         .addSubcommand("generate", new GenerateCommandLine())

--- a/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
@@ -31,7 +31,8 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
             GenerationConfig.Constants.GenerationTypes.FULL_SEQUENTIAL +
             ", " + GenerationConfig.Constants.GenerationTypes.INTERESTING +
             ", " + GenerationConfig.Constants.GenerationTypes.RANDOM + ").",
-        defaultValue = GenerationConfig.Constants.GenerationTypes.DEFAULT)
+        defaultValue = GenerationConfig.Constants.GenerationTypes.DEFAULT,
+        hidden = true)
     private GenerationConfig.DataGenerationType generationType;
 
     @CommandLine.Option(names = {"-c", "--combination-strategy"},

--- a/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
@@ -71,7 +71,8 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
 
     @CommandLine.Option(
         names = {"--trace-constraints"},
-        description = "Defines whether constraint tracing is enabled for the output")
+        description = "Defines whether constraint tracing is enabled for the output",
+        hidden = true)
     private boolean enableTracing;
 
     @CommandLine.Option(
@@ -97,7 +98,8 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
 
     @CommandLine.Option(
         names = {"--visualise-reductions"},
-        description = "Visualise each tree reduction")
+        description = "Visualise each tree reduction",
+        hidden = true)
     private Boolean visualiseReductions = false;
 
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
@@ -39,7 +39,8 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
             GenerationConfig.Constants.CombinationStrategies.PINNING + ", " +
             GenerationConfig.Constants.CombinationStrategies.EXHAUSTIVE + ", " +
             GenerationConfig.Constants.CombinationStrategies.MINIMAL + ").",
-        defaultValue = GenerationConfig.Constants.CombinationStrategies.DEFAULT)
+        defaultValue = GenerationConfig.Constants.CombinationStrategies.DEFAULT,
+        hidden = true)
     @SuppressWarnings("unused")
     private GenerationConfig.CombinationStrategyType combinationType;
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
@@ -151,7 +151,7 @@ public class GenerationConfig {
             public static final String INTERESTING = "INTERESTING";
             public static final String RANDOM = "RANDOM";
 
-            public static final String DEFAULT = INTERESTING;
+            public static final String DEFAULT = RANDOM;
         }
 
         public static class MonitorTypes {

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
@@ -160,6 +160,6 @@ public class GenerationConfig {
             public static final String STANDARD = "STANDARD";
         }
 
-        public static final long DEFAULT_MAX_ROWS = 10_000_000;
+        public static final long DEFAULT_MAX_ROWS = 1000;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/GenerationConfigValidator.java
@@ -31,7 +31,7 @@ public class GenerationConfigValidator implements ConfigValidator {
     public ValidationResult preProfileChecks(GenerationConfig config, GenerationConfigSource generationConfigSource) {
         ArrayList<String> errorMessages = new ArrayList<>();
 
-        checkSwitches(config, generationConfigSource, errorMessages);
+        checkSwitches(generationConfigSource, errorMessages);
 
         checkProfileInputFile(errorMessages, generationConfigSource.getProfileFile());
 
@@ -60,15 +60,9 @@ public class GenerationConfigValidator implements ConfigValidator {
         return new ValidationResult(errorMessages);
     }
 
-    private void checkSwitches(GenerationConfig config,
-                               GenerationConfigSource configSource,
+    private void checkSwitches(GenerationConfigSource configSource,
                                ArrayList<String> errorMessages) {
 
-        if (config.getDataGenerationType() == GenerationConfig.DataGenerationType.RANDOM
-            && !config.getMaxRows().isPresent()) {
-
-            errorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
-        }
         if (configSource.isEnableTracing()) {
             if (fileUtils.getTraceFile(configSource).exists() && !configSource.overwriteOutputFiles()) {
                 errorMessages.add("Invalid Output - trace file already exists, please use a different output filename or use the --overwrite option");

--- a/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/validators/GenerationConfigValidatorTests.java
@@ -86,23 +86,6 @@ public class GenerationConfigValidatorTests {
     }
 
     @Test
-    public void validateCommandLineOptions_randomWithNoMaxRows_correctErrorMessage() {
-        //Arrange
-        Mockito.reset(config);
-        when(config.getDataGenerationType()).thenReturn(GenerationConfig.DataGenerationType.RANDOM);
-        when(config.getMaxRows()).thenReturn(Optional.empty());
-        expectedErrorMessages.add("RANDOM mode requires max row limit: use -n=<row limit> option");
-        validator = new GenerationConfigValidator(mockFileUtils, mockConfigSource, mockOutputTarget);
-
-        //Act
-        ValidationResult actualResult = validator.preProfileChecks(config, mockConfigSource);
-
-        //Assert
-        assertThat("Validation result did not contain expected error message", actualResult, sameBeanAs(expectedResult));
-        Assert.assertFalse(actualResult.isValid());
-    }
-
-    @Test
     public void validateCommandLineOptions_traceConstraintsOutputFileDoesNotExist_returnsNoErrorMessages() {
         //Arrange
         when(mockConfigSource.isEnableTracing()).thenReturn(true);


### PR DESCRIPTION
### Description
Tidy-up process of aligning our documentation with PicoCli help and the reverse.

### Changes
- [x] `-c` & `--combination-strategy` are marked as `hidden` from help for `generate` and removed from documentation
- [x] `-w` & `--walker-type` are marked as `hidden` from help for `generate` and removed from documentation
- [x] `-t` & `--generation-type` are marked as `hidden` from help for `generate` and removed from documentation
- [x] `--trace-constraints`, `--visualise-reductions` are marked as `hidden` from help for `generate` and removed from documentation (keep the detail about what `--trace-constraints` does, but as an unlinked document
- [x] `--no-partition` is marked as `hidden` from help for `generate` and `visualise` and removed from documentation
- [x] `--no-simplify` and `--no-optimise` are marked as `hidden` from help for `generate` and `visualise` and removed from documentation
- [x] replace `dg` with `datahelix` so help shows `Usage: datahelix generate ...`
- [x] `RANDOM` is the default generation mode and update documentation to this effect
- [x] 1000 rows of data will be emitted in RANDOM mode if no other limit has been specified, the check for no limit is removed*
- [x] Remove 'full sequential' as a documented generation type, leave the code - only remove the description from documentation
- [x] `--overwrite` is unmarked as `hidden` so it *does* appear in the help for `generate` and `visualise`

### Additional notes
All tests run and pass in 12.481s

### Issue
Resolves #714