### PR TITLE
720- additional cucumbers steps for random

### DIFF
--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -122,6 +122,8 @@ And there is a constraint:
 * _{field} contains temporal values after or at {after}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or after _{after}_
 * _{field} contains numeric values less than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values less than or equal to _{value}_
 * _{field} contains numeric values greater than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values greater than or equal to _{value}_
+* _{field} contains strings shorter than or equal to {length}_, executes the generator and asserts that _field_ contains either `null` or string values shorter than or equal to _{length}_
+* _{field} contains strings longer than or equal to {length}_, executes the generator and asserts that _field_ contains either `null` or string values longer than or equal to _{length}_
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -118,6 +118,8 @@ And there is a constraint:
 * _{field} contains strings of length outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or strings with lengths outside _{min}_ and _{max}_.
 * _{field} contains strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that match the given regular expression.
 * _{field} contains anything but strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that do not match the given regular expression.
+* _{field} contains temporal values before or at {before}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or before _{before}_
+* _{field} contains temporal values after or at {after}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or after _{after}_
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -117,6 +117,7 @@ And there is a constraint:
 * _{field} contains numeric values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or numeric values outside _{min}_ and _{max}_.
 * _{field} contains strings of length outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or strings with lengths outside _{min}_ and _{max}_.
 * _{field} contains strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that match the given regular expression.
+* _{field} contains anything but strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that do not match the given regular expression.
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -110,6 +110,7 @@ And there is a constraint:
 * _{field} contains temporal values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or temporal values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains numeric values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or numeric values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains strings of length between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or strings with lengths between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
+* _{field} contains strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that match the given regular expression.
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -113,6 +113,9 @@ And there is a constraint:
 * _{field} contains temporal values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or temporal values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains numeric values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or numeric values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains strings of length between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or strings with lengths between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
+* _{field} contains temporal values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or temporal values outside _{min}_ and _{max}_.
+* _{field} contains numeric values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or numeric values outside _{min}_ and _{max}_.
+* _{field} contains strings of length outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or strings with lengths outside _{min}_ and _{max}_.
 * _{field} contains strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that match the given regular expression.
 
 ### Cucumber test style guide

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -120,6 +120,8 @@ And there is a constraint:
 * _{field} contains anything but strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that do not match the given regular expression.
 * _{field} contains temporal values before or at {before}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or before _{before}_
 * _{field} contains temporal values after or at {after}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or after _{after}_
+* _{field} contains numeric values less than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values less than or equal to _{value}_
+* _{field} contains numeric values greater than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values greater than or equal to _{value}_
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -104,8 +104,11 @@ And there is a constraint:
 
 ### Validating the data in the output
 * _{field} contains temporal data_, executes the generator and asserts that _field_ contains either `null` or temporal values
+* _{field} contains anything but temporal data_, executes the generator and asserts that _field_ contains either `null` or data that is not temporal.
 * _{field} contains numeric data_, executes the generator and asserts that _field_ contains either `null` or numeric values
+* _{field} contains anything but numeric data_, executes the generator and asserts that _field_ contains either `null` or data that is not numeric.
 * _{field} contains string data_, executes the generator and asserts that _field_ contains either `null` or string values
+* _{field} contains anything but string data_, executes the generator and asserts that _field_ contains either `null` or data that is not a string.
 * _{field} contains anything but null_, executes the generator and asserts that _field_ has a value in every row (i.e. no `null`s)
 * _{field} contains temporal values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or temporal values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains numeric values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or numeric values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.

--- a/docs/CucumberSyntax.md
+++ b/docs/CucumberSyntax.md
@@ -103,27 +103,35 @@ And there is a constraint:
 * _{number} of rows of data are generated_, executes the generator and asserts that exactly the given number of rows are generated
 
 ### Validating the data in the output
+
+#### Temporal
 * _{field} contains temporal data_, executes the generator and asserts that _field_ contains either `null` or temporal values
 * _{field} contains anything but temporal data_, executes the generator and asserts that _field_ contains either `null` or data that is not temporal.
+* _{field} contains temporal values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or temporal values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
+* _{field} contains temporal values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or temporal values outside _{min}_ and _{max}_.
+* _{field} contains temporal values before or at {before}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or before _{before}_
+* _{field} contains temporal values after or at {after}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or after _{after}_
+
+#### Numeric
 * _{field} contains numeric data_, executes the generator and asserts that _field_ contains either `null` or numeric values
 * _{field} contains anything but numeric data_, executes the generator and asserts that _field_ contains either `null` or data that is not numeric.
+* _{field} contains numeric values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or numeric values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
+* _{field} contains numeric values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or numeric values outside _{min}_ and _{max}_.
+* _{field} contains numeric values less than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values less than or equal to _{value}_
+* _{field} contains numeric values greater than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values greater than or equal to _{value}_
+
+#### String
 * _{field} contains string data_, executes the generator and asserts that _field_ contains either `null` or string values
 * _{field} contains anything but string data_, executes the generator and asserts that _field_ contains either `null` or data that is not a string.
-* _{field} contains anything but null_, executes the generator and asserts that _field_ has a value in every row (i.e. no `null`s)
-* _{field} contains temporal values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or temporal values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
-* _{field} contains numeric values between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or numeric values between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
 * _{field} contains strings of length between {min} and {max} inclusively_, executes the generator and asserts that _field_ contains either `null` or strings with lengths between _{min}_ and _{max}_. Does so in an inclusive manner for both min and max.
-* _{field} contains temporal values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or temporal values outside _{min}_ and _{max}_.
-* _{field} contains numeric values outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or numeric values outside _{min}_ and _{max}_.
 * _{field} contains strings of length outside {min} and {max}_, executes the generator and asserts that _field_ contains either `null` or strings with lengths outside _{min}_ and _{max}_.
 * _{field} contains strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that match the given regular expression.
 * _{field} contains anything but strings matching /{regex}/_, executes the generator and asserts that _field_ contains either `null` or strings that do not match the given regular expression.
-* _{field} contains temporal values before or at {before}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or before _{before}_
-* _{field} contains temporal values after or at {after}_, executes the generator and asserts that _field_ contains either `null` or temporal values at or after _{after}_
-* _{field} contains numeric values less than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values less than or equal to _{value}_
-* _{field} contains numeric values greater than or equal to {value}_, executes the generator and asserts that _field_ contains either `null` or numeric values greater than or equal to _{value}_
 * _{field} contains strings shorter than or equal to {length}_, executes the generator and asserts that _field_ contains either `null` or string values shorter than or equal to _{length}_
 * _{field} contains strings longer than or equal to {length}_, executes the generator and asserts that _field_ contains either `null` or string values longer than or equal to _{length}_
+
+#### Null (absence/presence)
+* _{field} contains anything but null_, executes the generator and asserts that _field_ has a value in every row (i.e. no `null`s)
 
 ### Cucumber test style guide
 * Tests should be written to validate one piece of logic only per test.

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -33,6 +33,11 @@ public class DateValueStep {
         helper.assertFieldContainsNullOrMatching(fieldName, LocalDateTime.class);
     }
 
+    @Then("{fieldVar} contains anything but temporal data")
+    public void producedDataShouldContainAnythingButStringValuesForField(String fieldName){
+        helper.assertFieldContainsNullOrNotMatching(fieldName, LocalDateTime.class);
+    }
+
     @Then("{fieldVar} contains temporal values between {date} and {date} inclusively")
     public void producedDataShouldContainTemporalValuesInRangeForField(String fieldName, DateObject minInclusive, DateObject maxInclusive){
         helper.assertFieldContainsNullOrMatching(

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -48,11 +48,11 @@ public class DateValueStep {
     }
 
     @Then("{fieldVar} contains temporal values outside {date} and {date}")
-    public void producedDataShouldContainTemporalValuesOutOfRangeForField(String fieldName, DateObject minInclusive, DateObject maxInclusive){
+    public void producedDataShouldContainTemporalValuesOutOfRangeForField(String fieldName, DateObject min, DateObject max){
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             LocalDateTime.class,
-            value -> !isBetweenInclusively(minInclusive, maxInclusive).apply(value));
+            value -> !isBetweenInclusively(min, max).apply(value));
     }
 
     @Then("{fieldVar} contains temporal values before or at {date}")

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -6,6 +6,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
 import java.time.LocalDateTime;
+import java.util.function.Function;
 
 public class DateValueStep {
 
@@ -43,7 +44,19 @@ public class DateValueStep {
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             LocalDateTime.class,
-            value -> isAfterOrAt(value, minInclusive) && isBeforeOrAt(value, maxInclusive));
+            isBetweenInclusively(minInclusive, maxInclusive));
+    }
+
+    @Then("{fieldVar} contains temporal values outside {date} and {date}")
+    public void producedDataShouldContainTemporalValuesOutOfRangeForField(String fieldName, DateObject minInclusive, DateObject maxInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            LocalDateTime.class,
+            value -> !isBetweenInclusively(minInclusive, maxInclusive).apply(value));
+    }
+
+    private Function<LocalDateTime, Boolean> isBetweenInclusively(DateObject minInclusive, DateObject maxInclusive){
+        return value -> isAfterOrAt(value, minInclusive) && isBeforeOrAt(value, maxInclusive);
     }
 
     private LocalDateTime getDateTime(DateObject dateObject){

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -55,6 +55,22 @@ public class DateValueStep {
             value -> !isBetweenInclusively(minInclusive, maxInclusive).apply(value));
     }
 
+    @Then("{fieldVar} contains temporal values before or at {date}")
+    public void producedDataShouldContainTemporalValuesBeforeForField(String fieldName, DateObject beforeInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            LocalDateTime.class,
+            value -> isBeforeOrAt(value, beforeInclusive));
+    }
+
+    @Then("{fieldVar} contains temporal values after or at {date}")
+    public void producedDataShouldContainTemporalValuesAfterForField(String fieldName, DateObject afterInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            LocalDateTime.class,
+            value -> isAfterOrAt(value, afterInclusive));
+    }
+
     private Function<LocalDateTime, Boolean> isBetweenInclusively(DateObject minInclusive, DateObject maxInclusive){
         return value -> isAfterOrAt(value, minInclusive) && isBeforeOrAt(value, maxInclusive);
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/GeneralTestStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/GeneralTestStep.java
@@ -222,7 +222,7 @@ public class GeneralTestStep {
     @Then("{long} rows of data are generated")
     public void theExpectedNumberOfRowsAreGenerated(long expectedNumberOfRows) {
         List <List<Object>> data = cucumberTestHelper.generateAndGetData();
-        Assert.assertThat("Unexpected number of rows returned", data.size(), equalTo(expectedNumberOfRows));
+        Assert.assertThat("Unexpected number of rows returned", (long)data.size(), equalTo(expectedNumberOfRows));
     }
 
     @Given("the generator can generate at most {long} rows")

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
@@ -6,6 +6,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
 import java.math.BigDecimal;
+import java.util.function.Function;
 
 import static com.scottlogic.deg.generator.utils.NumberUtils.coerceToBigDecimal;
 
@@ -44,7 +45,19 @@ public class NumericValueStep {
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             Number.class,
-            value -> isGreaterThanOrEqual(value, minInclusive) && isLessThanOrEqual(value, maxInclusive));
+            isBetweenInclusively(minInclusive, maxInclusive));
+    }
+
+    @Then("{fieldVar} contains numeric values outside {number} and {number}")
+    public void producedDataShouldContainNumericValuesOutOfRangeForField(String fieldName, Number minInclusive, Number maxInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            Number.class,
+            value -> !isBetweenInclusively(minInclusive, maxInclusive).apply(value));
+    }
+
+    private Function<Number, Boolean> isBetweenInclusively(Number minInclusive, Number maxInclusive){
+        return value -> isGreaterThanOrEqual(value, minInclusive) && isLessThanOrEqual(value, maxInclusive);
     }
 
     private boolean isGreaterThanOrEqual(Number value, Number minInclusive){

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
@@ -65,11 +65,11 @@ public class NumericValueStep {
     }
 
     @Then("{fieldVar} contains numeric values outside {number} and {number}")
-    public void producedDataShouldContainNumericValuesOutOfRangeForField(String fieldName, Number minInclusive, Number maxInclusive){
+    public void producedDataShouldContainNumericValuesOutOfRangeForField(String fieldName, Number min, Number max){
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             Number.class,
-            value -> !isBetweenInclusively(minInclusive, maxInclusive).apply(value));
+            value -> !isBetweenInclusively(min, max).apply(value));
     }
 
     private Function<Number, Boolean> isBetweenInclusively(Number minInclusive, Number maxInclusive){

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
@@ -34,6 +34,11 @@ public class NumericValueStep {
         helper.assertFieldContainsNullOrMatching(fieldName, Number.class);
     }
 
+    @Then("{fieldVar} contains anything but numeric data")
+    public void producedDataShouldContainAnythingButStringValuesForField(String fieldName){
+        helper.assertFieldContainsNullOrNotMatching(fieldName, Number.class);
+    }
+
     @Then("{fieldVar} contains numeric values between {number} and {number} inclusively")
     public void producedDataShouldContainNumericValuesInRangeForField(String fieldName, Number minInclusive, Number maxInclusive){
         helper.assertFieldContainsNullOrMatching(

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/NumericValueStep.java
@@ -48,6 +48,22 @@ public class NumericValueStep {
             isBetweenInclusively(minInclusive, maxInclusive));
     }
 
+    @Then("{fieldVar} contains numeric values less than or equal to {number}")
+    public void producedDataShouldContainNumericValuesLessThanForField(String fieldName, Number lessThanInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            Number.class,
+            value -> isLessThanOrEqual(value, lessThanInclusive));
+    }
+
+    @Then("{fieldVar} contains numeric values greater than or equal to {number}")
+    public void producedDataShouldContainNumericValuesGreaterThanForField(String fieldName, Number greaterThanInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            Number.class,
+            value -> isGreaterThanOrEqual(value, greaterThanInclusive));
+    }
+
     @Then("{fieldVar} contains numeric values outside {number} and {number}")
     public void producedDataShouldContainNumericValuesOutOfRangeForField(String fieldName, Number minInclusive, Number maxInclusive){
         helper.assertFieldContainsNullOrMatching(

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/RegexValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/RegexValueStep.java
@@ -1,14 +1,20 @@
 package com.scottlogic.deg.generator.cucumber.steps;
 
+import com.scottlogic.deg.generator.cucumber.utils.CucumberTestHelper;
 import com.scottlogic.deg.generator.cucumber.utils.CucumberTestState;
+import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+
+import java.util.regex.Pattern;
 
 public class RegexValueStep {
 
     private final CucumberTestState state;
+    private final CucumberTestHelper helper;
 
-    public RegexValueStep(CucumberTestState state){
+    public RegexValueStep(CucumberTestState state, CucumberTestHelper helper){
         this.state = state;
+        this.helper = helper;
     }
 
     @When("{fieldVar} is {operator} {regex}")
@@ -19,5 +25,15 @@ public class RegexValueStep {
     @When("{fieldVar} is anything but {operator} {regex}")
     public void whenFieldIsNotConstrainedByRegex(String fieldName, String constraintName, String value) throws Exception {
         this.state.addNotConstraint(fieldName, constraintName, value);
+    }
+
+    @Then("{fieldVar} contains strings matching {regex}")
+    public void producedDataShouldContainStringValuesMatchingRegex(String fieldName, String regex){
+        Pattern pattern = Pattern.compile(regex);
+
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            String.class,
+            value -> pattern.matcher(value).matches());
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/RegexValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/RegexValueStep.java
@@ -36,4 +36,14 @@ public class RegexValueStep {
             String.class,
             value -> pattern.matcher(value).matches());
     }
+
+    @Then("{fieldVar} contains anything but strings matching {regex}")
+    public void producedDataShouldContainStringValuesNotMatchingRegex(String fieldName, String regex){
+        Pattern pattern = Pattern.compile(regex);
+
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            String.class,
+            value -> !pattern.matcher(value).matches());
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
@@ -5,6 +5,8 @@ import com.scottlogic.deg.generator.cucumber.utils.CucumberTestState;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
+import java.util.function.Function;
+
 public class StringValueStep {
 
     private final CucumberTestState state;
@@ -40,7 +42,19 @@ public class StringValueStep {
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             String.class,
-            value -> isLongerThanOrEqual(value, minInclusive) && isShorterThanOrEqual(value, maxInclusive));
+            isLengthBetweenInclusively(minInclusive, maxInclusive));
+    }
+
+    @Then("{fieldVar} contains strings of length outside {int} and {int}")
+    public void producedDataShouldContainStringValuesOutOfRangeForField(String fieldName, int minInclusive, int maxInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            String.class,
+            value -> !isLengthBetweenInclusively(minInclusive, maxInclusive).apply(value));
+    }
+
+    private Function<String, Boolean> isLengthBetweenInclusively(int minInclusive, int maxInclusive){
+        return value -> isLongerThanOrEqual(value, minInclusive) && isShorterThanOrEqual(value, maxInclusive);
     }
 
     private boolean isShorterThanOrEqual(String value, int maxLengthInclusive) {

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
@@ -45,6 +45,22 @@ public class StringValueStep {
             isLengthBetweenInclusively(minInclusive, maxInclusive));
     }
 
+    @Then("{fieldVar} contains strings shorter than or equal to {int}")
+    public void producedDataShouldContainStringValuesShorterThanForField(String fieldName, int shorterThanInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            String.class,
+            value -> isShorterThanOrEqual(value, shorterThanInclusive));
+    }
+
+    @Then("{fieldVar} contains strings longer than or equal to {int}")
+    public void producedDataShouldContainStringValuesLongerThanForField(String fieldName, int longerThanInclusive){
+        helper.assertFieldContainsNullOrMatching(
+            fieldName,
+            String.class,
+            value -> isLongerThanOrEqual(value, longerThanInclusive));
+    }
+
     @Then("{fieldVar} contains strings of length outside {int} and {int}")
     public void producedDataShouldContainStringValuesOutOfRangeForField(String fieldName, int minInclusive, int maxInclusive){
         helper.assertFieldContainsNullOrMatching(

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
@@ -30,6 +30,11 @@ public class StringValueStep {
         helper.assertFieldContainsNullOrMatching(fieldName, String.class);
     }
 
+    @Then("{fieldVar} contains anything but string data")
+    public void producedDataShouldContainAnythingButStringValuesForField(String fieldName){
+        helper.assertFieldContainsNullOrNotMatching(fieldName, String.class);
+    }
+
     @Then("{fieldVar} contains strings of length between {int} and {int} inclusively")
     public void producedDataShouldContainStringValuesInRangeForField(String fieldName, int minInclusive, int maxInclusive){
         helper.assertFieldContainsNullOrMatching(

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
@@ -62,11 +62,11 @@ public class StringValueStep {
     }
 
     @Then("{fieldVar} contains strings of length outside {int} and {int}")
-    public void producedDataShouldContainStringValuesOutOfRangeForField(String fieldName, int minInclusive, int maxInclusive){
+    public void producedDataShouldContainStringValuesOutOfRangeForField(String fieldName, int min, int max){
         helper.assertFieldContainsNullOrMatching(
             fieldName,
             String.class,
-            value -> !isLengthBetweenInclusively(minInclusive, maxInclusive).apply(value));
+            value -> !isLengthBetweenInclusively(min, max).apply(value));
     }
 
     private Function<String, Boolean> isLengthBetweenInclusively(int minInclusive, int maxInclusive){

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/StringValueStep.java
@@ -5,8 +5,6 @@ import com.scottlogic.deg.generator.cucumber.utils.CucumberTestState;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 
-import java.math.BigInteger;
-
 public class StringValueStep {
 
     private final CucumberTestState state;

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestHelper.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/utils/CucumberTestHelper.java
@@ -87,6 +87,20 @@ public class CucumberTestHelper {
         });
     }
 
+    public <T> void assertFieldContainsNullOrNotMatching(String fieldName, Class<T> clazz){
+        assertFieldContains(fieldName, objectValue -> {
+            if (objectValue == null){
+                return true;
+            }
+
+            if (clazz.isInstance(objectValue)){
+                return false; //matches, but shouldn't match the type
+            }
+
+            return true;
+        });
+    }
+
     public void assertFieldContains(String fieldName, Function<Object, Boolean> predicate){
         Optional<Integer> fieldIndex = getIndexOfField(fieldName);
         if (!fieldIndex.isPresent()){


### PR DESCRIPTION
### Description
Cucumber steps only support a limited number of data characteristic checks, this pull request introduces more.

### Changes
- Introduced regex matching/not-matching checks
- Introduced not-within (i.e. outside) range checks for numeric, temporal and string-lengths
- Introduced before/less/shorter than or equal checks for temporal, numeric and strings as appropriate
- Introduced after/more/longer than or equal checks for temporal, numeric and strings as appropriate
- Updated documentation to describe changes
- Fix for #719- number of rows generated step

### Issue
Resolves #720