### PR TITLE
702- Integration with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2 
+jobs:
+  build:
+    docker:
+      - image: circleci/openjdk:8-jdk-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: datahelix-{{ checksum "pom.xml" }}
+      - run: mvn dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: datahelix-{{ checksum "pom.xml" }}
+      - run: mvn package
+workflows:
+  version: 2
+  build_and_test: 
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,6 @@ jobs:
       - image: circleci/openjdk:8-jdk-browsers
     steps:
       - checkout
-      - restore_cache:
-          key: datahelix-{{ checksum "pom.xml" }}
-      - run: mvn dependency:go-offline
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: datahelix-{{ checksum "pom.xml" }}
       - run: mvn package
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ jobs:
     steps:
       - checkout
       - run: mvn package
+      - run:
+          command: |
+            mkdir -p ~/cucumber
+            bundle exec cucumber --format junit --out ~/cucumber/junit.xml
+      - store_test_results:
+          path: ~/cucumber
 workflows:
   version: 2
   build_and_test: 


### PR DESCRIPTION
### Description
Updating GitHub to build and run tests through a different platform to:
- [ ] Increase visibility of detail (publicly, no need for access to AWS)
- [ ] Ensure builds happen at the right time (pull-requests created and pull-requests merged to master)
- [ ] Provide more detail back to GitHub
- [ ] Provides a build badge for the readme!

Resolves #702