### PR TITLE
719- fix for date regex in cucumber

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/steps/DateValueStep.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 
 public class DateValueStep {
 
-    public static final String DATE_REGEX = "(-?(\\d{4,19})-(\\d{2})-(\\d{2}T(\\d{2}:\\d{2}:\\d{2}\\.\\d{3})))$";
+    public static final String DATE_REGEX = "(-?(\\d{4,19})-(\\d{2})-(\\d{2}T(\\d{2}:\\d{2}:\\d{2}\\.\\d{3})))";
     private final CucumberTestState state;
     private final CucumberTestHelper helper;
 


### PR DESCRIPTION
### Description
Date regular expression for cucumber steps includes a `$` anchor, meaning all dates need to be at the end of a step. The changes for #719 require dates to be permitted anywhere in a step

### Changes
- Removal to `$` anchor to permit dates within the content (not just at the end) of a step

### Additional notes
Was previously working, but regressed as part of fb8f7f4

### Issue
Relates to #719