### PR TITLE
702- added travis ci file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+script: mvn clean test


### PR DESCRIPTION
Configuration for travis-ci if this becomes the CI tool for this project. The reporting on failing unit tests doesn't match Circle CI so it won't be used.

Travis CI is connected to the project but is currently turned off.