### PR TITLE
Correct typo in generate documentation

### DIFF
--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -6,7 +6,7 @@ Option switches are case-sensitive, arguments are case-insensitive
 * `--violate`
    * Generate data which violates profile constraints.
 * `--dont-violate` <epistemic constraints...>
-   * Choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=typeOf lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints.
+   * Choose specific [epicstemic constraints](../EpistemicConstraints.md) to [not violate](../generator/docs/SelectiveViolation.md), e.g. "--dont-violate=ofType lessThan" will not violate ANY data type constraints and will also not violate ANY less than constraints.
 * `-n <rows>` or `--max-rows <rows>`
    * Emit at most `<rows>` rows to the output file, if not specified will limit to 10,000,000 rows.
    * Mandatory in `RANDOM` mode.


### PR DESCRIPTION
### Description
 Fix typo in documentation

### Changes
* Corrected "ofType" to "typeOf" in generation docs
