### PR TITLE
672 contradictory temporal fixes

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictions.java
@@ -79,5 +79,9 @@ public class DateTimeRestrictions {
         public int hashCode() {
             return Objects.hash(limit, inclusive);
         }
+
+        public boolean isAfter(DateTimeLimit other) {
+            return limit.isAfter(other.limit);
+        }
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictions.java
@@ -80,8 +80,19 @@ public class DateTimeRestrictions {
             return Objects.hash(limit, inclusive);
         }
 
-        public boolean isAfter(DateTimeLimit other) {
-            return limit.isAfter(other.limit);
+        public boolean isAfter(DateTimeLimit max) {
+            LocalDateTime minLimit = getReferenceTime(1);
+            LocalDateTime maxLimit = max.getReferenceTime(-1);
+
+            return minLimit.isAfter(maxLimit);
+        }
+
+        private LocalDateTime getReferenceTime(int nanoOffset){
+            if (inclusive){
+                return limit;
+            }
+
+            return limit.plusNanos(nanoOffset);
         }
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMerger.java
@@ -22,7 +22,7 @@ public class DateTimeRestrictionsMerger {
             return new MergeResult<>(merged);
         }
 
-        if (merged.min.getLimit().isAfter(merged.max.getLimit())) {
+        if (merged.min.isAfter(merged.max)) {
             return new MergeResult<>();
         }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/After.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/After.feature
@@ -81,8 +81,6 @@ Scenario: 'Not After' with a non-contradicting 'Not After' is successful
     | 0004-01-01T00:00:00.000 |
     | 0005-01-01T00:00:00.000 |
 
-#Defect #672 - Request for contradictory After and Not After should only generate null
-@ignore
 Scenario: 'After' with a contradicting 'Not After' generates null
   Given foo is after 2019-01-01T00:00:00.000
     And foo is anything but after 2019-01-01T00:00:00.000
@@ -144,8 +142,6 @@ Then the following data should be generated:
   | 0004-01-01T00:00:00.000 |
   | 0005-01-01T00:00:00.000 |
 
-#Defect #672 - Request for contradictory After and Not After should only generate null
-@ignore
 Scenario: 'After' with a contradicting 'Not After Or At' only generates null
 Given foo is after 2019-01-01T00:00:00.000
   And foo is anything but after or at 2019-01-01T00:00:00.000

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsMergerTests.java
@@ -162,4 +162,64 @@ class DateTimeRestrictionsMergerTests {
         Assert.assertThat(result.restrictions.min, is(nullValue()));
         Assert.assertThat(result.restrictions.max, equalTo(maxDateTimeLimit));
     }
+
+    @Test
+    void merge_minExclusiveSameAsMaxInclusive_shouldReturnAsUnsuccessful() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+        LocalDateTime referenceTime = LocalDateTime.now();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, true
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
+    }
+
+    @Test
+    void merge_minExclusiveSameAsMaxExclusive_shouldReturnAsUnsuccessful() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+        LocalDateTime referenceTime = LocalDateTime.now();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, false
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
+    }
+
+    @Test
+    void merge_minInclusiveSameAsMaxExclusive_shouldReturnAsUnsuccessful() {
+        DateTimeRestrictionsMerger merger = new DateTimeRestrictionsMerger();
+        LocalDateTime referenceTime = LocalDateTime.now();
+
+        DateTimeRestrictions.DateTimeLimit minDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, true
+        );
+        DateTimeRestrictions.DateTimeLimit maxDateTimeLimit = new DateTimeRestrictions.DateTimeLimit(
+            referenceTime, false
+        );
+        DateTimeRestrictions left = new DateTimeRestrictions() {{ max = maxDateTimeLimit; }};
+        DateTimeRestrictions right = new DateTimeRestrictions() {{ min = minDateTimeLimit; }};
+
+        MergeResult<DateTimeRestrictions> result = merger.merge(left, right);
+
+        Assert.assertThat(result, not(nullValue()));
+        Assert.assertThat(result.successful, is(false));
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
@@ -2,13 +2,10 @@ package com.scottlogic.deg.generator.restrictions;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-import org.mockito.cglib.core.Local;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAmount;
-import java.time.temporal.TemporalUnit;
 
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 
@@ -216,6 +213,124 @@ class DateTimeRestrictionsTests {
         boolean result = restrictions.match(min);
 
         Assert.assertFalse(result);
+    }
+
+    @Test
+    public void isAfter_whenSameDateAndBothInclusive_shouldBeFalse(){
+        LocalDateTime value = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(value, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(value, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(false));
+    }
+
+    @Test
+    public void isAfter_whenSameDateAndOtherIsExclusive_shouldBeTrue(){
+        LocalDateTime value = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(value, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(value, false);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(true));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsBeforeByOneNanoSecondInclusive_shouldBeFalse(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = selfValue.plusNanos(-1);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(false));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsBeforeByOneNanoSecondExclusive_shouldBeFalse(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = selfValue.plusNanos(-1);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, false);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(false));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsBeforeInclusive_shouldBeFalse(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = LocalDateTime.of(2000, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(false));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsBeforeExclusive_shouldBeFalse(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = LocalDateTime.of(2000, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, false);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(false));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsAfterInclusive_shouldBeTrue(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = LocalDateTime.of(2002, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(true));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsAfterExclusive_shouldBeTrue(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = LocalDateTime.of(2002, 02, 03, 04, 05, 06);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, false);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(true));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsAfterByOneNanoSecondInclusive_shouldBeTrue(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = selfValue.plusNanos(1);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(true));
+    }
+
+    @Test
+    public void isAfter_whenOtherIsAfterByOneNanoSecondExclusive_shouldBeTrue(){
+        LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
+        LocalDateTime otherValue = selfValue.plusNanos(1);
+        DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, false);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+
+        boolean result = other.isAfter(self);
+
+        Assert.assertThat(result, is(true));
     }
 
     private DateTimeRestrictions restrictions(MockDateTimeLimit min, MockDateTimeLimit max){

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DateTimeRestrictionsTests.java
@@ -326,7 +326,7 @@ class DateTimeRestrictionsTests {
         LocalDateTime selfValue = LocalDateTime.of(2001, 02, 03, 04, 05, 06);
         LocalDateTime otherValue = selfValue.plusNanos(1);
         DateTimeRestrictions.DateTimeLimit self = new DateTimeRestrictions.DateTimeLimit(selfValue, false);
-        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, true);
+        DateTimeRestrictions.DateTimeLimit other = new DateTimeRestrictions.DateTimeLimit(otherValue, false);
 
         boolean result = other.isAfter(self);
 


### PR DESCRIPTION
### Description
Currently temporal constraints that contradict allows for one value to be created where it shouldn't. See #672 for further detail. This change updates the contradiction checking to be more thorough to prevent this circumstance.

### Changes
- Update contradiction checking to take into account exclusive ranges (i.e. after/before vs afterOrAt/beforeOrAt - which are inclusive)
- Introduced new unit tests for changed logic, see `DateTimeRestrictionsTests`, which test `DateTimeLimit`.
- Unignored previously ignored cucumber scenarios

### Additional notes
Branched off #611 to prevent merge conflicts in future, requires #611 to be merged first.

### Testing notes
The following tests have been added:

#### DateTimeRestrictions, merge

| min | max | expected & actual |
| ---- | ---- | ---- |
| > 1900-01-01 | <= 1900-01-01 | contradiction |
| > 1900-01-01 | < 1900-01-01 | contradiction | 
| >= 1900-01-01 | < 1900-01-01 | contradiction |

#### DateTimeLimit
| min/other | inclusive | max/self | inclusive | expected & actual |
| ---- | ---- | ---- | ---- | ---- |
| 2001-01-01T00:00:00.000 | inc | 2001-01-01T00:00:00.000 | inc | false |
| 2001-01-01T00:00:00.000 | excl | 2001-01-01T00:00:00.000 | inc | true |
| 2000-12-31T23:59:59.999999999 | inc | 2001-01-01T00:00:00.000 | inc | false |
| 2000-12-31T23:59:59.999999999 | excl | 2001-01-01T00:00:00.000 | inc | false |
| 1999-01-01T00:00:00.000 | inc | 2001-01-01T00:00:00.000 | inc | false |
| 1999-01-01T00:00:00.000 | excl | 2001-01-01T00:00:00.000 | inc | false |
| 2019-01-01T00:00:00.000 | inc | 2001-01-01T00:00:00.000 | inc | true |
| 2019-01-01T00:00:00.000 | excl | 2001-01-01T00:00:00.000 | inc | true |
| 2019-01-01T00:00:00.000000001 | inc | 2001-01-01T00:00:00.000 | inc | true |
| 2019-01-01T00:00:00.000000001 | excl | 2001-01-01T00:00:00.000 | inc | true |

### Issue
Resolves #672