### PR TITLE
707 - Sensible numeric max min

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
@@ -8,6 +8,7 @@ import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.ReportingProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.reporters.SystemOutProfileValidationReporter;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 public class GenerationConfig {
@@ -183,5 +184,8 @@ public class GenerationConfig {
         }
 
         public static final long DEFAULT_MAX_ROWS = 1000;
+
+        public static final BigDecimal NUMERIC_MAX = new BigDecimal("1e20");
+        public static final BigDecimal NUMERIC_MIN = new BigDecimal("-1e20");
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.generation.fieldvaluesources;
 
+import com.scottlogic.deg.generator.generation.GenerationConfig;
 import com.scottlogic.deg.generator.restrictions.NumericLimit;
 import com.scottlogic.deg.generator.restrictions.NumericRestrictions;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
@@ -229,8 +230,8 @@ class RealNumberFieldValueSourceTests {
 
         expectInterestingValues(
             4, 5,
-            BigDecimal.valueOf(Double.MAX_VALUE).subtract(BigDecimal.ONE),
-            BigDecimal.valueOf(Double.MAX_VALUE));
+            GenerationConfig.Constants.NUMERIC_MAX.subtract(BigDecimal.ONE),
+            GenerationConfig.Constants.NUMERIC_MAX);
     }
 
     @Test
@@ -238,19 +239,19 @@ class RealNumberFieldValueSourceTests {
         givenUpperBound(4, true);
 
         expectInterestingValues(
-            BigDecimal.valueOf(Double.MAX_VALUE).negate(),
-            BigDecimal.valueOf(Double.MAX_VALUE).negate().add(BigDecimal.ONE),
+            GenerationConfig.Constants.NUMERIC_MIN,
+            GenerationConfig.Constants.NUMERIC_MIN.add(BigDecimal.ONE),
             0, 3, 4);
     }
 
     @Test
     void shouldSupplyToBoundary() {
         expectInterestingValues(
-            BigDecimal.valueOf(Double.MAX_VALUE).negate(),
-            BigDecimal.valueOf(Double.MAX_VALUE).negate().add(BigDecimal.ONE),
+            GenerationConfig.Constants.NUMERIC_MIN,
+            GenerationConfig.Constants.NUMERIC_MIN.add(BigDecimal.ONE),
             0,
-            BigDecimal.valueOf(Double.MAX_VALUE).subtract(BigDecimal.ONE),
-            BigDecimal.valueOf(Double.MAX_VALUE)
+            GenerationConfig.Constants.NUMERIC_MAX.subtract(BigDecimal.ONE),
+            GenerationConfig.Constants.NUMERIC_MAX
         );
     }
 

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSourceTests.java
@@ -408,6 +408,82 @@ class RealNumberFieldValueSourceTests {
         Assert.assertThat(a, not(equalTo(b)));
     }
 
+    @Test
+    public void interestingValuesInclusively_UpperLimitLargerThanConfig_IncludesConfigMax() {
+        givenLowerBound(-10, true);
+        givenUpperBound(1e30, true);
+        givenScale(0);
+
+        expectInterestingValues(new BigDecimal("1e20"), "99999999999999999999", "0", "-9", "-10");
+    }
+
+    @Test
+    public void exhaustiveValuesInclusively_UpperLimitLargerThanConfig_IncludesConfigMax() {
+        givenLowerBound(new BigDecimal("99999999999999999995"), true);
+        givenUpperBound(1e30, true);
+        givenScale(0);
+
+        expectAllValues(new BigDecimal("1e20"), "99999999999999999999",
+            "99999999999999999998", "99999999999999999997", "99999999999999999996", "99999999999999999995");
+    }
+
+    @Test
+    public void interestingValuesExclusively_UpperLimitLargerThanConfig_IncludesConfigMaxMinusOne() {
+        givenLowerBound(-10, false);
+        givenUpperBound(1e30, false);
+        givenScale(0);
+
+        expectInterestingValues("99999999999999999999", "99999999999999999998", "0", "-8", "-9");
+    }
+
+    @Test
+    public void exhaustiveValuesExclusively_UpperLimitLargerThanConfig_IncludesConfigMaxMinusOne() {
+        givenLowerBound(new BigDecimal("99999999999999999995"), false);
+        givenUpperBound(1e30, false);
+        givenScale(0);
+
+        expectAllValues("99999999999999999999", "99999999999999999998", "99999999999999999997",
+            "99999999999999999996");
+    }
+
+    @Test
+    public void interestingValuesInclusively_LowerLimitSmallerThanConfig_IncludesConfigMin() {
+        givenLowerBound(-1e30, true);
+        givenUpperBound(10, true);
+        givenScale(0);
+
+        expectInterestingValues(new BigDecimal("-1e20"), "-99999999999999999999", "0", "9", "10");
+    }
+
+    @Test
+    public void exhaustiveValuesInclusively_LowerLimitSmallerThanConfig_IncludesConfigMin() {
+        givenLowerBound(-1e30, true);
+        givenUpperBound(new BigDecimal("-99999999999999999995"), true);
+        givenScale(0);
+
+        expectAllValues(new BigDecimal("-1e20"), "-99999999999999999999",
+            "-99999999999999999998", "-99999999999999999997", "-99999999999999999996", "-99999999999999999995");
+    }
+
+    @Test
+    public void interestingValuesExclusively_LowerLimitSmallerThanConfig_IncludesConfigMinPlusOne() {
+        givenLowerBound(-1e30, false);
+        givenUpperBound(10, false);
+        givenScale(0);
+
+        expectInterestingValues("-99999999999999999999", "-99999999999999999998", "0", "8", "9");
+    }
+
+    @Test
+    public void exhaustiveValuesExclusively_LowerLimitSmallerThanConfig_IncludesConfigMinPlusOne() {
+        givenLowerBound(-1e30, false);
+        givenUpperBound(new BigDecimal("-99999999999999999995"), false);
+        givenScale(0);
+
+        expectAllValues( "-99999999999999999999", "-99999999999999999998", "-99999999999999999997",
+            "-99999999999999999996");
+    }
+
     private NumericRestrictions numericRestrictions(Integer min, Integer max){
         NumericRestrictions restrictions = new NumericRestrictions();
         restrictions.min = min == null ? null : new NumericLimit<>(BigDecimal.valueOf(min), true);

--- a/generator/src/test/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookupTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/inputs/AtomicConstraintReaderLookupTests.java
@@ -4,6 +4,7 @@ import com.scottlogic.deg.generator.Field;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.constraints.Constraint;
 import com.scottlogic.deg.generator.constraints.atomic.*;
+import com.scottlogic.deg.generator.generation.GenerationConfig;
 import com.scottlogic.deg.schemas.v0_1.AtomicConstraintType;
 import com.scottlogic.deg.schemas.v0_1.ConstraintDTO;
 import com.scottlogic.deg.schemas.v0_1.RuleDTO;
@@ -117,6 +118,33 @@ public class AtomicConstraintReaderLookupTests {
             Arguments.of(AtomicConstraintType.ISSTRINGSHORTERTHAN, nullValueDto));
     }
 
+    private static Stream<Arguments> numericOutOfBoundsOperandProvider() {
+
+        ConstraintDTO maxValueDtoPlusOne = new ConstraintDTO();
+        maxValueDtoPlusOne.field = "test";
+        maxValueDtoPlusOne.value = GenerationConfig.Constants.NUMERIC_MAX.add(BigDecimal.ONE);
+
+        ConstraintDTO minValueDtoMinusOne = new ConstraintDTO();
+        minValueDtoMinusOne.field = "test";
+        minValueDtoMinusOne.value = GenerationConfig.Constants.NUMERIC_MIN.subtract(BigDecimal.ONE);
+
+        return Stream.of(
+            Arguments.of(AtomicConstraintType.ISEQUALTOCONSTANT, maxValueDtoPlusOne),
+            Arguments.of(AtomicConstraintType.ISINSET, maxValueDtoPlusOne),
+            Arguments.of(AtomicConstraintType.ISGREATERTHANOREQUALTOCONSTANT, maxValueDtoPlusOne),
+            Arguments.of(AtomicConstraintType.ISGREATERTHANCONSTANT, maxValueDtoPlusOne),
+            Arguments.of(AtomicConstraintType.ISLESSTHANOREQUALTOCONSTANT, maxValueDtoPlusOne),
+            Arguments.of(AtomicConstraintType.ISLESSTHANCONSTANT, maxValueDtoPlusOne),
+
+            Arguments.of(AtomicConstraintType.ISEQUALTOCONSTANT, minValueDtoMinusOne),
+            Arguments.of(AtomicConstraintType.ISINSET, minValueDtoMinusOne),
+            Arguments.of(AtomicConstraintType.ISGREATERTHANOREQUALTOCONSTANT, minValueDtoMinusOne),
+            Arguments.of(AtomicConstraintType.ISGREATERTHANCONSTANT, minValueDtoMinusOne),
+            Arguments.of(AtomicConstraintType.ISLESSTHANOREQUALTOCONSTANT, minValueDtoMinusOne),
+            Arguments.of(AtomicConstraintType.ISLESSTHANCONSTANT, minValueDtoMinusOne)
+        );
+    }
+
     private static Stream<Arguments> stringLengthValidOperandProvider() {
 
         ConstraintDTO integerAsDecimalDto = new ConstraintDTO();
@@ -194,6 +222,19 @@ public class AtomicConstraintReaderLookupTests {
     @ParameterizedTest(name = "{0} should be invalid")
     @MethodSource("stringLengthInvalidOperandProvider")
     public void testAtomicConstraintReaderWithInvalidOperands(AtomicConstraintType type, ConstraintDTO dto) {
+        ConstraintReader reader = atomicConstraintReaderLookup.getByTypeCode(type.toString());
+
+        RuleDTO rule = new RuleDTO();
+        rule.rule = "rule";
+        Set<RuleInformation> ruleInformation = Collections.singleton(new RuleInformation(rule));
+
+        Assertions.assertThrows(InvalidProfileException.class, () -> reader.apply(dto, profileFields, ruleInformation));
+    }
+
+    @DisplayName("Should fail when value property is numeric and out of bounds")
+    @ParameterizedTest(name = "{0} should be invalid")
+    @MethodSource("numericOutOfBoundsOperandProvider")
+    public void testAtomicConstraintReaderWithOutOfBoundValues(AtomicConstraintType type, ConstraintDTO dto) {
         ConstraintReader reader = atomicConstraintReaderLookup.getByTypeCode(type.toString());
 
         RuleDTO rule = new RuleDTO();

--- a/schemas/src/main/resources/profileschema/0.1/datahelix.schema.json
+++ b/schemas/src/main/resources/profileschema/0.1/datahelix.schema.json
@@ -180,13 +180,27 @@
             "properties": {
               "is": {
                 "enum": [
-                  "shorterThan", "longerThan", "greaterThan", "lessThan", "greaterThanOrEqualTo", "lessThanOrEqualTo", "granularTo"
+                  "shorterThan", "longerThan", "granularTo"
                 ]
               }
             }
           },
           "then": {
-            "properties": {"value": {"type": "number"}}
+            "properties": {"value": {"type": "number" }}
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "is": {
+                "enum": [
+                  "greaterThan", "lessThan", "greaterThanOrEqualTo", "lessThanOrEqualTo"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {"value": {"type": "number", "maximum": 1E20, "minimum": -1E20}}
           }
         },
         {

--- a/schemas/src/test/java/com/scottlogic/deg/schemas/v0_1/ProfileValidatorTests.java
+++ b/schemas/src/test/java/com/scottlogic/deg/schemas/v0_1/ProfileValidatorTests.java
@@ -3,6 +3,8 @@ package com.scottlogic.deg.schemas.v0_1;
 import com.scottlogic.deg.schemas.common.ValidationResult;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.InputStream;
 
@@ -156,6 +158,30 @@ class ProfileValidatorTests {
     @Test
     void validateProfile_temporal_fails() {
         ValidationResult result = validate("/test-profiles/profile-test-simple-temporals-errors.json");
+        Assert.assertFalse("Profile should not be valid", result.isValid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/test-profiles/profile-test-greaterThan-max.json",
+        "/test-profiles/profile-test-greaterThanOrEqualTo-max.json",
+        "/test-profiles/profile-test-lessThan-min.json",
+        "/test-profiles/profile-test-lessThanOrEqualTo-min.json"
+    })
+    void validateProfile_numericMinMax_success(String filePath) {
+        ValidationResult result = validate(filePath);
+        Assert.assertTrue("Profile should not be valid", result.isValid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/test-profiles/profile-test-greaterThan-max-errors.json",
+        "/test-profiles/profile-test-greaterThanOrEqualTo-max-errors.json",
+        "/test-profiles/profile-test-lessThan-min-errors.json",
+        "/test-profiles/profile-test-lessThanOrEqualTo-min-errors.json"
+    })
+    void validateProfile_numericMinMax_fails(String filePath) {
+        ValidationResult result = validate(filePath);
         Assert.assertFalse("Profile should not be valid", result.isValid());
     }
 }

--- a/schemas/src/test/resources/test-profiles/profile-test-greaterThan-max-errors.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-greaterThan-max-errors.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "greaterThan",
+          "value": 1E21 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-greaterThan-max.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-greaterThan-max.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "greaterThan",
+          "value": 1E20 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-greaterThanOrEqualTo-max-errors.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-greaterThanOrEqualTo-max-errors.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "greaterThanOrEqualTo",
+          "value": 1E21 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-greaterThanOrEqualTo-max.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-greaterThanOrEqualTo-max.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "greaterThanOrEqualTo",
+          "value": 1E20 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-lessThan-min-errors.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-lessThan-min-errors.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "lessThan",
+          "value": -1E21 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-lessThan-min.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-lessThan-min.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "lessThan",
+          "value": -1E20 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-lessThanOrEqualTo-min-errors.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-lessThanOrEqualTo-min-errors.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "lessThanOrEqualTo",
+          "value": -1E21 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}

--- a/schemas/src/test/resources/test-profiles/profile-test-lessThanOrEqualTo-min.json
+++ b/schemas/src/test/resources/test-profiles/profile-test-lessThanOrEqualTo-min.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "0.1",
+  "rules": [
+    {
+      "rule": "rule 1",
+      "constraints": [
+        {
+          "field": "field1",
+          "is": "lessThanOrEqualTo",
+          "value": -1E20 
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "field1"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Introduce a "sensible" maximum and minimum for numeric values to be +/-1E20, respectively.

### Changes
- Place new `MAX` and `MIN` values in the `GenerationConfig`
- Made new exception if number is out of the min max bounds
- Added a guard to further prevent numbers larger/smaller than the min/max to make it through to generation
- Updated the schema to also check when the user is writing their profile

### Issue
Resolves #707 