### PR TITLE
817- Added cucumber test and profile for a hard contradiction

### DIFF
--- a/examples/hard-contradiction-range-and-granular/README.md
+++ b/examples/hard-contradiction-range-and-granular/README.md
@@ -1,0 +1,2 @@
+It is a hard contradiction to say that a field can only be a decimal field between zero and one exclusive, and also must
+be granular to one (i.e. an integer).

--- a/examples/hard-contradiction-range-and-granular/profile.json
+++ b/examples/hard-contradiction-range-and-granular/profile.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "0.1",
+  "fields": [
+    {
+      "name": "Column 1"
+    }
+  ],
+  "rules": [
+    {
+      "rule": "Column 1 is greaterThan 0",
+      "constraints": [
+        {
+          "field": "Column 1",
+          "is": "greaterThan",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "rule": "Column 1 is lessThan 1",
+      "constraints": [
+        {
+          "field": "Column 1",
+          "is": "lessThan",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "rule": "Column 1 is granularTo 1",
+      "constraints": [
+        {
+          "field": "Column 1",
+          "is": "granularTo",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "rule": "Column 1 is not null",
+      "constraints": [
+        {
+          "not": {
+            "field": "Column 1",
+            "is": "null"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Contradictions.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/Contradictions.feature
@@ -11,6 +11,14 @@ Scenario: Contradicting types, disallowing 'null', should not produce any data.
   And foo is of type "integer"
   Then no data is created
 
+@ignore #issue #817
+Scenario: Contradicting inferred and actual types should not produce any data.
+  Given foo is anything but null
+  And foo is of type "integer"
+  And foo is less than 1
+  And foo is greater than 0
+  Then no data is created
+
 ### Soft Contradictions ###
 Scenario: Contradicting types, but allowing 'null', should produce only 'null' values.
   Given foo is of type "string"


### PR DESCRIPTION
### Description
Covers the situation where the type is integer but the value is less than 1 and greater than 0

### Changes
Added profile and test.

### Additional notes
Moves location of `Contradictions.feature`

### Issue
Related to #817 