### PR TITLE
795 granular to works with in sets

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/GranularityRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/GranularityRestrictions.java
@@ -3,6 +3,8 @@ package com.scottlogic.deg.generator.restrictions;
 import java.math.BigDecimal;
 import java.util.Objects;
 
+import static com.scottlogic.deg.generator.utils.NumberUtils.coerceToBigDecimal;
+
 public class GranularityRestrictions {
     private final int numericScale;
 
@@ -14,9 +16,9 @@ public class GranularityRestrictions {
         this.numericScale = numericScale;
     }
 
-    public static boolean isCorrectScale(Number o, double granularity) {
-        BigDecimal granularityAsBigDecimal = new BigDecimal(o.toString());
-        return granularityAsBigDecimal.scale() <= granularity;
+    public static boolean isCorrectScale(Number inputNumber, double granularity) {
+        BigDecimal inputAsBigDecimal = coerceToBigDecimal(inputNumber);
+        return inputAsBigDecimal.scale() <= granularity;
     }
 
     public int getNumericScale() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/GranularityRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/GranularityRestrictions.java
@@ -1,5 +1,6 @@
 package com.scottlogic.deg.generator.restrictions;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 public class GranularityRestrictions {
@@ -11,6 +12,11 @@ public class GranularityRestrictions {
 
     private GranularityRestrictions(int numericScale) {
         this.numericScale = numericScale;
+    }
+
+    public static boolean isCorrectScale(Number o, double granularity) {
+        BigDecimal granularityAsBigDecimal = new BigDecimal(o.toString());
+        return granularityAsBigDecimal.scale() <= granularity;
     }
 
     public int getNumericScale() {

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
@@ -1356,7 +1356,7 @@ Scenario: 'InSet' with a non contradicting not 'granularTo' is successful
       | 1.1  |
 
 @ignore #issue #824 - 2.0 should be generated with a granularity of 1
-Scenario: Not 'inSet' with a non contradicting 'granularTo' is successful
+Scenario: Integer within an inSet and a non contradicting 'granularTo' is successful
   Given there is a field foo
     And foo is granular to 1
     And foo is in set:
@@ -1368,6 +1368,19 @@ Scenario: Not 'inSet' with a non contradicting 'granularTo' is successful
       | null |
       | 1    |
       | 2.0  |
+
+Scenario: Not 'inSet' with a non contradicting 'granularTo' is successful
+  Given there is a field foo
+    And foo is anything but in set:
+      | 1.1 |
+    And foo is granular to 1
+    And foo is in set:
+      | 1.1 |
+      | 1   |
+  Then the following data should be generated:
+      | foo  |
+      | null |
+      | 1    |
 
 Scenario Outline: 'InSet' of a non-numeric type value with a non contradicting 'granularTo' is successful
   Given there is a field foo

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
@@ -1355,6 +1355,7 @@ Scenario: 'InSet' with a non contradicting not 'granularTo' is successful
       | null |
       | 1.1  |
 
+@ignore #issue #824 - 2.0 should be generated with a granularity of 1
 Scenario: Not 'inSet' with a non contradicting 'granularTo' is successful
   Given there is a field foo
     And foo is granular to 1

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
@@ -1357,8 +1357,6 @@ Scenario: 'InSet' with a non contradicting not 'granularTo' is successful
 
 Scenario: Not 'inSet' with a non contradicting 'granularTo' is successful
   Given there is a field foo
-    And foo is anything but in set:
-      | 1.1 |
     And foo is granular to 1
     And foo is in set:
       | 1.1 |

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/Null.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/Null.feature
@@ -348,7 +348,6 @@ Scenario: 'Null' with a contradicting not 'lessThanOrEqualTo' should only genera
 
 ### granularTo ###
 
-@ignore #Relates to issue #677 - Granularity ignored when generating from set
 Scenario: Not 'null' with a non contradicting 'granularTo' should be successful
   Given foo is anything but null
     And foo is granular to 1

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/types/Integer.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/types/Integer.feature
@@ -60,7 +60,6 @@ Scenario: Equal to constraint with integer type produces valid integer
     | foo |
     | 10  |
 
-@ignore #795 - Using equalTo constraint on field of type integer allows generation of non-integer value
 Scenario: Equal to constraint with integer type rejects invalid integer (decimal)
   Given foo is equal to 10.1
   Then no data is created


### PR DESCRIPTION
### Description
Granular to constraints were not being checked against inSet constraints. i.e. previously, granular to 1 and in Set [1.2] would generate 1.2. This PR changes this so that no contradicting data is generated.

### Changes
- Added `isCorrectScale` method to granularToRestrcitions to check the scale of a numeric value from a set is correct
- Unignored cucumber scenarios relating to issues

### Additional notes
Found new bug related to granular to, #824 

### Issue
Resolves #795 
Resolves #677 