### PR TITLE
Add bugs to the 'bug board' automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -2,6 +2,7 @@
 name: 🐛 Bug Report
 about: If something isn't working as expected 🤔.
 labels: bug
+projects: scottlogic/15
 ---
 
 ## Bug Report


### PR DESCRIPTION
### Description
Automatically assign bugs to the bug-board, will go into the 'To Triage' column by default.