### PR TITLE
768- Allow fields to be untyped via a CLI switch

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
@@ -108,6 +108,12 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
         defaultValue = GenerationConfig.Constants.OutputFormats.DEFAULT)
     private GenerationConfig.OutputFormat outputFormat;
 
+    @CommandLine.Option(
+        names = {"--allow-untyped-fields"},
+        description = "Remove the need for each field to have at least one compliant typing constraint applied",
+        defaultValue = GenerationConfig.Constants.OutputFormats.DEFAULT)
+    private boolean allowUntypedFields = false;
+
     public boolean shouldDoPartitioning() {
         return !this.dontPartitionTrees;
     }
@@ -165,6 +171,11 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
     @Override
     public List<AtomicConstraintType> getConstraintsToNotViolate() {
         return constraintsToNotViolate;
+    }
+
+    @Override
+    public boolean requireFieldTyping(){
+        return !allowUntypedFields;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
@@ -32,6 +32,7 @@ public interface GenerationConfigSource extends ConfigSource {
     boolean overwriteOutputFiles();
     boolean visualiseReductions();
     boolean shouldViolate();
+    boolean requireFieldTyping();
 
     GenerationConfig.OutputFormat getOutputFormat();
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/ProfileValidatorProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/ProfileValidatorProvider.java
@@ -7,6 +7,8 @@ import com.scottlogic.deg.generator.inputs.validation.*;
 import com.scottlogic.deg.generator.validators.GenerationConfigValidator;
 import com.scottlogic.deg.generator.validators.GenerationOutputValidator;
 
+import java.util.ArrayList;
+
 public class ProfileValidatorProvider implements Provider<ProfileValidator> {
     private final GenerationConfigSource configSource;
     private final ProfileContradictionsValidator contradictionCheckingValidator;
@@ -28,15 +30,18 @@ public class ProfileValidatorProvider implements Provider<ProfileValidator> {
 
     @Override
     public ProfileValidator get() {
+        ArrayList<ProfileValidator> validators = new ArrayList<>();
+
         if(configSource.getValidateProfile()) {
-            return new MultipleProfileValidator(
-                contradictionCheckingValidator,
-                untypedValidator,
-                outputValidator);
+            validators.add(contradictionCheckingValidator);
         }
 
-        return new MultipleProfileValidator(
-            untypedValidator,
-            outputValidator);
+        if(configSource.requireFieldTyping()) {
+            validators.add(untypedValidator);
+        }
+
+        validators.add(outputValidator);
+
+        return new MultipleProfileValidator(validators);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/MultipleProfileValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/MultipleProfileValidator.java
@@ -8,16 +8,20 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 public class MultipleProfileValidator implements ProfileValidator{
-    private final ProfileValidator[] validators;
+    private final Collection<ProfileValidator> validators;
 
     public MultipleProfileValidator(ProfileValidator... validators) {
+        this.validators = Arrays.asList(validators);
+    }
+
+    public MultipleProfileValidator(Collection<ProfileValidator> validators) {
         this.validators = validators;
     }
 
     @Override
     public Collection<ValidationAlert> validate(Profile profile) {
         return FlatMappingSpliterator.flatMap(
-            Arrays.stream(validators),
+            validators.stream(),
             validator -> validator.validate(profile).stream())
             .collect(Collectors.toList());
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -19,6 +19,11 @@ public class CucumberGenerationConfigSource implements GenerationConfigSource {
     }
 
     @Override
+    public boolean requireFieldTyping() {
+        return state.requireFieldTyping;
+    }
+
+    @Override
     public GenerationConfig.DataGenerationType getGenerationType() {
         return state.dataGenerationType;
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestState.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestState.java
@@ -24,6 +24,7 @@ public class CucumberTestState {
      * If true, generation is in violate mode.
      */
     public Boolean shouldViolate = false;
+    public boolean requireFieldTyping = true;
 
     /** If true, we inject a no-op generation engine during the test (e.g. because we're just testing profile validation) */
     private Boolean shouldSkipGeneration = false;

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
@@ -16,6 +16,7 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     public boolean validateProfile = false;
     public Path outputPath;
     public GenerationConfig.OutputFormat outputFormat = GenerationConfig.OutputFormat.CSV;
+    public boolean requireFieldTyping = true;
 
     public TestGenerationConfigSource(
         GenerationConfig.DataGenerationType generationType,
@@ -24,6 +25,11 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
         this.generationType = generationType;
         this.combinationStrategy = combinationStrategy;
         this.walkerType = walkerType;
+    }
+
+    @Override
+    public boolean requireFieldTyping() {
+        return requireFieldTyping;
     }
 
     @Override


### PR DESCRIPTION
### Description
Type mandatoriness (mandation) changes are on by default and there is no means to disable them. This change allows for this process to be disabled via a command line interface (CLI) switch.

### Changes
- Introduce CLI switch --allow-untyped-fields
- Only include the 'type mandatoriness' validator if the CLI switch isn't provided

### Issue
Resolves #768