### PR TITLE
885 fix visualise reductions

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/ReductiveDecisionTreeWalker.java
@@ -82,10 +82,10 @@ public class ReductiveDecisionTreeWalker implements DecisionTreeWalker {
         }
 
         monitor.fieldFixedToValue(fieldValue.getField(), fieldValue.getValue());
-        visualise(reducedTree.get(), reductiveState);
 
         ReductiveState newReductiveState =
             reductiveState.withFixedFieldValue(fieldValue);
+        visualise(reducedTree.get(), newReductiveState);
 
         if (newReductiveState.allFieldsAreFixed()){
             return Stream.of(reductiveRowSpecGenerator.createRowSpecsFromFixedValues(newReductiveState));

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveState.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveState.java
@@ -49,12 +49,14 @@ public class ReductiveState {
     }
 
     public String toString(boolean detailAllFields) {
-        return fieldValues.size() > 10 && !detailAllFields
-            ? String.format("Fixed fields: %d of %d", this.fieldValues.size(), this.fields.size())
-            : String.join(", ", this.fieldValues.values()
+        if (fieldValues.size() > 10 && !detailAllFields){
+            return String.format("Fixed fields: %d of %d", this.fieldValues.size(), this.fields.size());
+        }
+
+        return String.join(", ", this.fieldValues.values()
             .stream()
-            .sorted(Comparator.comparing(ff -> ff.getValue().toString()))
-            .map(FieldValue::toString)
+            .sorted(Comparator.comparing(ff -> ff.getField().toString()))
+            .map(ff -> String.format("%s: %s", ff.getField(), ff.getValue()))
             .collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
### Description
show useful description for visualise reductions

### Changes
fix tostring in reductive state
call next reductive state rather than previous, when visualising

![56209229-ec4fa600-604a-11e9-8a71-42bf29570631](https://user-images.githubusercontent.com/44771131/56281782-63e20b80-6105-11e9-81da-344910546c04.png)

Resolves #885 