### PR TITLE
141 - Temporal Granularity Tests

### DIFF
--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo-DateTime.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo-DateTime.feature
@@ -1,0 +1,42 @@
+Feature: User can specify that datetime fields are granular to a certain unit
+
+  Background:
+    Given the generation strategy is full
+    And there is a field foo
+    And foo is anything but null
+    And foo is of type "datetime"
+
+  @ignore #awaiting development from rest of 141
+  Scenario Outline: User is able to specify supported temporal granularities
+    Given foo is granular to <unit>
+    And foo is after 2000-01-01T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo       |
+      | <output>  |
+
+    Examples:
+      | unit      | output                    |
+      | "millis"  | 2000-01-01T00:00:00.001Z  |
+      | "seconds" | 2000-01-01T00:00:01.000Z  |
+      | "minutes" | 2000-01-01T00:01:00.000Z  |
+      | "hours"   | 2000-01-01T01:00:00.000Z  |
+      | "days"    | 2000-01-02T00:00:00.000Z  |
+      | "months"  | 2000-02-01T00:00:00.000Z  |
+      | "years"   | 2001-01-01T00:00:00.000Z  |
+
+  @ignore #awaiting development from rest of 141
+  Scenario: Applying two valid datetime granularTo constraints generates data that matches both (coarser)
+    Given foo is granular to "millis"
+    And foo is granular to "seconds"
+    And foo is after 2000-01-01T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo                       |
+      | 2000-01-01T00:00:01.000Z  |
+
+  @ignore #awaiting development from rest of 141
+  Scenario: Applying an invalid datetime granularTo constraint fails with an appropriate error
+    Given foo is granular to "decades"
+    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be a Number or one of the supported datetime units (millis, seconds, minutes, hours, days, months, years)"
+    And no data is created

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo-Decimal.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo-Decimal.feature
@@ -1,13 +1,13 @@
-Feature: User can specify that decimal or datetime fields are granular to a certain level
+Feature: User can specify that decimal fields are granular to a certain number of decimal places
 
   Background:
     Given the generation strategy is full
     And there is a field foo
     And foo is anything but null
+    And foo is of type "decimal"
 
   Scenario: User requires to create a numeric field with data values that include a decimal value to one decimal point
     Given foo is granular to 0.1
-    And foo is of type "decimal"
     And foo is greater than or equal to 0
     And foo is less than or equal to 1
     Then the following data should be generated:
@@ -27,7 +27,6 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
   @ignore #issue related to 867
   Scenario: User requires to create a numeric field with data values that include a decimal value to two decimal points
     Given foo is granular to 0.01
-    And foo is of type "decimal"
     And foo is greater than or equal to 0
     And foo is less than or equal to 0.2
     Then the following data should be generated:
@@ -56,7 +55,6 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
 
   Scenario: User requires to create a numeric field with negative data values that include a decimal value to one decimal point
     Given foo is granular to 0.1
-    And foo is of type "decimal"
     And foo is less than or equal to 0
     And foo is greater than or equal to -1
     Then the following data should be generated:
@@ -75,20 +73,17 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
 
   Scenario: User attempts to create a numeric field with data value that include a decimal value to one decimal point incorrectly using a string to set the granularity
     Given foo is granular to "0.1"
-    And foo is of type "decimal"
     Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be a Number but was a String with value `0.1`"
     And no data is created
 
   Scenario: Running a 'granularTo' request that specifies null should be unsuccessful
     Given foo is granular to null
-    And foo is of type "decimal"
     Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
     And no data is created
 
 
   Scenario: Running granularTo against a non contradicting granularTo should be successful
     Given foo is granular to 1
-    And foo is of type "decimal"
     And foo is granular to 1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -102,7 +97,6 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
 
   Scenario: Running granularTo against a non contradicting granularTo should be successful
     Given foo is granular to 1
-    And foo is of type "decimal"
     And foo is granular to 0.1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -117,7 +111,6 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
   @ignore #issue 769 not sure what is expected result
   Scenario: Running granularTo run against a non contradicting not granularTo should be successful
     Given foo is granular to 1
-    And foo is of type "decimal"
     And foo is anything but granular to 0.1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -132,7 +125,6 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
   @ignore #issue 769 not sure what is expected result
   Scenario: Running not granularTo against a non contradicting not granularTo should be successful
     Given foo is anything but granular to 1
-    And foo is of type "decimal"
     And foo is anything but granular to 0.1
     And the generator can generate at most 4 rows
     Then the following data should be generated:
@@ -141,43 +133,3 @@ Feature: User can specify that decimal or datetime fields are granular to a cert
       | 0.3 |
       | 0.4 |
       | 0.5 |
-
-### DATETIME
-
-  @ignore #awaiting development from rest of 141
-  Scenario Outline: User is able to specify supported temporal granularities
-    Given foo is granular to <unit>
-    And foo is of type "datetime"
-    And foo is after 2000-01-01T00:00:00.000Z
-    And the generator can generate at most 1 rows
-    Then the following data should be generated:
-      | foo       |
-      | <output>  |
-
-    Examples:
-      | unit      | output                    |
-      | "millis"  | 2000-01-01T00:00:00.001Z  |
-      | "seconds" | 2000-01-01T00:00:01.000Z  |
-      | "minutes" | 2000-01-01T00:01:00.000Z  |
-      | "hours"   | 2000-01-01T01:00:00.000Z  |
-      | "days"    | 2000-01-02T00:00:00.000Z  |
-      | "months"  | 2000-02-01T00:00:00.000Z  |
-      | "years"   | 2001-01-01T00:00:00.000Z  |
-
-  @ignore #awaiting development from rest of 141
-  Scenario: Applying two valid datetime granularTo constraints generates data that matches both (coarser)
-    Given foo is granular to "millis"
-    And foo is granular to "seconds"
-    And foo is of type "datetime"
-    And foo is after 2000-01-01T00:00:00.000Z
-    And the generator can generate at most 1 rows
-    Then the following data should be generated:
-      | foo                       |
-      | 2000-01-01T00:00:01.000Z  |
-
-  @ignore #awaiting development from rest of 141
-  Scenario: Applying an invalid datetime granularTo constraint fails with an appropriate error
-    Given foo is granular to "decades"
-    And foo is of type "datetime"
-    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be a Number or one of the supported datetime units (millis, seconds, minutes, hours, days, months, years)"
-    And no data is created

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/GranularTo.feature
@@ -1,13 +1,13 @@
-Feature: User can specify that a numeric value is of a decimalised value to a specified level of unit
+Feature: User can specify that decimal or datetime fields are granular to a certain level
 
   Background:
     Given the generation strategy is full
     And there is a field foo
-    And foo is of type "decimal"
     And foo is anything but null
 
   Scenario: User requires to create a numeric field with data values that include a decimal value to one decimal point
     Given foo is granular to 0.1
+    And foo is of type "decimal"
     And foo is greater than or equal to 0
     And foo is less than or equal to 1
     Then the following data should be generated:
@@ -27,6 +27,7 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
   @ignore #issue related to 867
   Scenario: User requires to create a numeric field with data values that include a decimal value to two decimal points
     Given foo is granular to 0.01
+    And foo is of type "decimal"
     And foo is greater than or equal to 0
     And foo is less than or equal to 0.2
     Then the following data should be generated:
@@ -55,6 +56,7 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
 
   Scenario: User requires to create a numeric field with negative data values that include a decimal value to one decimal point
     Given foo is granular to 0.1
+    And foo is of type "decimal"
     And foo is less than or equal to 0
     And foo is greater than or equal to -1
     Then the following data should be generated:
@@ -73,17 +75,20 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
 
   Scenario: User attempts to create a numeric field with data value that include a decimal value to one decimal point incorrectly using a string to set the granularity
     Given foo is granular to "0.1"
+    And foo is of type "decimal"
     Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be a Number but was a String with value `0.1`"
     And no data is created
 
   Scenario: Running a 'granularTo' request that specifies null should be unsuccessful
     Given foo is granular to null
+    And foo is of type "decimal"
     Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be set to a value"
     And no data is created
 
 
   Scenario: Running granularTo against a non contradicting granularTo should be successful
     Given foo is granular to 1
+    And foo is of type "decimal"
     And foo is granular to 1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -97,6 +102,7 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
 
   Scenario: Running granularTo against a non contradicting granularTo should be successful
     Given foo is granular to 1
+    And foo is of type "decimal"
     And foo is granular to 0.1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -111,6 +117,7 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
   @ignore #issue 769 not sure what is expected result
   Scenario: Running granularTo run against a non contradicting not granularTo should be successful
     Given foo is granular to 1
+    And foo is of type "decimal"
     And foo is anything but granular to 0.1
     And foo is greater than 0
     And the generator can generate at most 5 rows
@@ -125,6 +132,7 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
   @ignore #issue 769 not sure what is expected result
   Scenario: Running not granularTo against a non contradicting not granularTo should be successful
     Given foo is anything but granular to 1
+    And foo is of type "decimal"
     And foo is anything but granular to 0.1
     And the generator can generate at most 4 rows
     Then the following data should be generated:
@@ -134,10 +142,42 @@ Feature: User can specify that a numeric value is of a decimalised value to a sp
       | 0.4 |
       | 0.5 |
 
+### DATETIME
 
+  @ignore #awaiting development from rest of 141
+  Scenario Outline: User is able to specify supported temporal granularities
+    Given foo is granular to <unit>
+    And foo is of type "datetime"
+    And foo is after 2000-01-01T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo       |
+      | <output>  |
 
+    Examples:
+      | unit      | output                    |
+      | "millis"  | 2000-01-01T00:00:00.001Z  |
+      | "seconds" | 2000-01-01T00:00:01.000Z  |
+      | "minutes" | 2000-01-01T00:01:00.000Z  |
+      | "hours"   | 2000-01-01T01:00:00.000Z  |
+      | "days"    | 2000-01-02T00:00:00.000Z  |
+      | "months"  | 2000-02-01T00:00:00.000Z  |
+      | "years"   | 2001-01-01T00:00:00.000Z  |
 
+  @ignore #awaiting development from rest of 141
+  Scenario: Applying two valid datetime granularTo constraints generates data that matches both (coarser)
+    Given foo is granular to "millis"
+    And foo is granular to "seconds"
+    And foo is of type "datetime"
+    And foo is after 2000-01-01T00:00:00.000Z
+    And the generator can generate at most 1 rows
+    Then the following data should be generated:
+      | foo                       |
+      | 2000-01-01T00:00:01.000Z  |
 
-
-
-
+  @ignore #awaiting development from rest of 141
+  Scenario: Applying an invalid datetime granularTo constraint fails with an appropriate error
+    Given foo is granular to "decades"
+    And foo is of type "datetime"
+    Then the profile is invalid because "Field \[foo\]: Couldn't recognise 'value' property, it must be a Number or one of the supported datetime units (millis, seconds, minutes, hours, days, months, years)"
+    And no data is created


### PR DESCRIPTION
### Description
 Introducing temporal granularity in #141 will require creation of new steps, errors, and potentially feature files. I'm opening up this draft PR with some potential tests so we can discuss the names of new steps and where the tests should be located.

### New steps & errors
Given \<field\> is granular to \<unit\>

Error: "Field \[\<field\>\]: Couldn't recognise 'value' property, it must be a Number or one of the supported datetime units (millis, seconds, minutes, hours, days, months, years)"

### Test location
Presently the new tests are located with the decimal granularto tests in GranularTo.feature
Matt has raised concern that we have too few, overly large/complicated, features and suggested splitting this file into seperate features for decimals & datetimes. What would people prefer?