### PR TITLE
create getBigDecimal for random

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
@@ -110,11 +110,10 @@ public class RealNumberFieldValueSource implements FieldValueSource {
         return () -> new UpCastingIterator<>(
             new FilteringIterator<>(
                 new SupplierBasedIterator<>(() ->
-                    new BigDecimal(
-                        randomNumberGenerator.nextDouble(
-                            inclusiveLowerLimit.doubleValue(),
-                            inclusiveUpperLimit.doubleValue()
-                        )).setScale(scale, RoundingMode.HALF_UP)),
+                    randomNumberGenerator.nextBigDecimal(
+                        inclusiveLowerLimit.doubleValue(),
+                        inclusiveUpperLimit.doubleValue(),
+                        scale)),
                 i -> !blacklist.contains(i)));
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/fieldvaluesources/RealNumberFieldValueSource.java
@@ -111,8 +111,8 @@ public class RealNumberFieldValueSource implements FieldValueSource {
             new FilteringIterator<>(
                 new SupplierBasedIterator<>(() ->
                     randomNumberGenerator.nextBigDecimal(
-                        inclusiveLowerLimit.doubleValue(),
-                        inclusiveUpperLimit.doubleValue(),
+                        inclusiveLowerLimit,
+                        inclusiveUpperLimit,
                         scale)),
                 i -> !blacklist.contains(i)));
     }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
@@ -52,10 +52,10 @@ public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator {
     }
 
     @Override
-    public BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale) {
+    public BigDecimal nextBigDecimal(BigDecimal lowerInclusive, BigDecimal upperExclusive, int scale) {
         return new BigDecimal(random.nextDouble())
-            .multiply(new BigDecimal(upperExclusive - lowerInclusive))
-            .add(new BigDecimal(lowerInclusive))
+            .multiply(upperExclusive.subtract(lowerInclusive))
+            .add(lowerInclusive)
             .setScale(scale, RoundingMode.HALF_UP);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/JavaUtilRandomNumberGenerator.java
@@ -1,5 +1,7 @@
 package com.scottlogic.deg.generator.utils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Random;
 
 public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator {
@@ -47,5 +49,13 @@ public class JavaUtilRandomNumberGenerator implements RandomNumberGenerator {
     @Override
     public double nextDouble(double lowerInclusive, double upperExclusive) {
         return random.nextDouble() * (upperExclusive - lowerInclusive) + lowerInclusive;
+    }
+
+    @Override
+    public BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale) {
+        return new BigDecimal(random.nextDouble())
+            .multiply(new BigDecimal(upperExclusive - lowerInclusive))
+            .add(new BigDecimal(lowerInclusive))
+            .setScale(scale, RoundingMode.HALF_UP);
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
@@ -1,8 +1,11 @@
 package com.scottlogic.deg.generator.utils;
 
+import java.math.BigDecimal;
+
 public interface RandomNumberGenerator {
     int nextInt();
     int nextInt(int bound);
     int nextInt(int lowerInclusive, int upperExclusive);
     double nextDouble(double lowerInclusive, double upperExclusive);
+    BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale);
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/utils/RandomNumberGenerator.java
@@ -7,5 +7,5 @@ public interface RandomNumberGenerator {
     int nextInt(int bound);
     int nextInt(int lowerInclusive, int upperExclusive);
     double nextDouble(double lowerInclusive, double upperExclusive);
-    BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale);
+    BigDecimal nextBigDecimal(BigDecimal lowerInclusive, BigDecimal upperExclusive, int scale);
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
@@ -452,8 +452,8 @@ public class DateTimeFieldValueSourceTests {
         }
 
         @Override
-        public BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale) {
-            return new BigDecimal(nextDouble(lowerInclusive, upperExclusive));
+        public BigDecimal nextBigDecimal(BigDecimal lowerInclusive, BigDecimal upperExclusive, int scale) {
+            return new BigDecimal(nextDouble(lowerInclusive.doubleValue(), upperExclusive.doubleValue()));
         }
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/fieldvaluesources/datetime/DateTimeFieldValueSourceTests.java
@@ -5,6 +5,7 @@ import com.scottlogic.deg.generator.utils.RandomNumberGenerator;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -448,6 +449,11 @@ public class DateTimeFieldValueSourceTests {
         @Override
         public double nextDouble(double lower, double upper) {
             return nextDoubleValue * (upper - lower) + lower;
+        }
+
+        @Override
+        public BigDecimal nextBigDecimal(double lowerInclusive, double upperExclusive, int scale) {
+            return new BigDecimal(nextDouble(lowerInclusive, upperExclusive));
         }
     }
 }


### PR DESCRIPTION
### Description
when using double for random generation of large numbers
it lost precision and generated only integers.

### Changes
Created nextBigDecimal method for use in random.
it uses bigDecimal, so does not lose precision

### Additional notes
### Issue
Resolves #850 