### PR TITLE
strip trailing zeros when checking scale

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/NumericRestrictions.java
@@ -59,9 +59,8 @@ public class NumericRestrictions {
         return BigDecimal.ONE.scaleByPowerOfTen(numericScale * -1);
     }
 
-    private boolean isCorrectScale(Number inputNumber) {
-        BigDecimal inputAsBigDecimal = coerceToBigDecimal(inputNumber);
-        return inputAsBigDecimal.scale() <= numericScale;
+    private boolean isCorrectScale(BigDecimal inputNumber) {
+        return inputNumber.stripTrailingZeros().scale() <= numericScale;
     }
 
     @Override

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/features/operators/InSet.feature
@@ -1355,7 +1355,6 @@ Feature: User can specify that a field value belongs to a set of predetermined o
       | null |
       | 1.1  |
 
-  @ignore #issue #824 - 2.0 should be generated with a granularity of 1
   Scenario: Integer within an inSet and a non contradicting 'granularTo' is successful
     Given there is a field foo
     And foo is granular to 1


### PR DESCRIPTION
### Description
Scale wasn't being checked properly, 2.0 didn't count as an integer

### Changes
strip trailing zeros when checking scale
enable test

### Issue
 Resolves #824 