### PR TITLE
863- Hide exception output during cucumber runs

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/GenerateExecute.java
@@ -79,7 +79,7 @@ public class GenerateExecute implements Runnable {
             generationEngine.generateDataSet(profile, config, outputTarget);
 
         } catch (IOException | InvalidProfileException e) {
-            e.printStackTrace();
+            errorReporter.displayException(e);
         }
     }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/validators/ErrorReporter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/validators/ErrorReporter.java
@@ -6,4 +6,8 @@ public class ErrorReporter {
     public void display(ValidationResult validationResult) {
         validationResult.errorMessages.forEach(e -> System.err.println("* " + e));
     }
+
+    public void displayException(Exception e) {
+        e.printStackTrace(System.err);
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberErrorReporter.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberErrorReporter.java
@@ -1,0 +1,22 @@
+package com.scottlogic.deg.generator.cucumber.testframework.utils;
+
+import com.scottlogic.deg.generator.validators.ErrorReporter;
+import com.scottlogic.deg.schemas.common.ValidationResult;
+
+public class CucumberErrorReporter extends ErrorReporter {
+    private final CucumberTestState state;
+
+    public CucumberErrorReporter(CucumberTestState state) {
+        this.state = state;
+    }
+
+    @Override
+    public void display(ValidationResult validationResult) {
+        super.display(validationResult);
+    }
+
+    @Override
+    public void displayException(Exception e) {
+        state.addException(e);
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestModule.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestModule.java
@@ -7,17 +7,16 @@ import com.scottlogic.deg.generator.GenerationEngine;
 import com.scottlogic.deg.generator.StandardGenerationEngine;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
 import com.scottlogic.deg.generator.inputs.ProfileReader;
-import com.scottlogic.deg.generator.inputs.validation.MultipleProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.TypingRequiredPerFieldValidator;
 import com.scottlogic.deg.generator.inputs.validation.reporters.ProfileValidationReporter;
 import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
 import com.scottlogic.deg.generator.validators.ConfigValidator;
+import com.scottlogic.deg.generator.validators.ErrorReporter;
 import com.scottlogic.deg.generator.violations.ViolationGenerationEngine;
-import com.scottlogic.deg.schemas.v0_1.ProfileSchemaValidator;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * Class which defines bindings for Guice injection specific for cucumber testing. The test state is persisted through
@@ -41,6 +40,7 @@ public class CucumberTestModule extends AbstractModule {
         bind(ConfigValidator.class).to(CucumberGenerationConfigValidator.class);
         bind(ProfileValidationReporter.class).toInstance(testState.validationReporter);
         bind(ProfileValidator.class).to(TypingRequiredPerFieldValidator.class);
+        bind(ErrorReporter.class).toInstance(new CucumberErrorReporter(testState));
 
         if (testState.shouldSkipGeneration()) {
             bind(GenerationEngine.class).toInstance(mock(GenerationEngine.class));


### PR DESCRIPTION
### Description
When running cucumber features, any unhandled exception (or invalid profile exceptions) are printed to the output, polluting the display. This pull request ensures these exceptions are captured and no longer pollute the output.

### Changes
- Ensure thrown exceptions are captured and can be asserted against
- Ensure thrown exceptions do not get printed to output when running via Cucumber

### Additional notes
- Error reporter will still emit the error details in 'run' mode, as before - no change to behaviour

### Issue
Resolves #863