### PR TITLE
Re-enable code coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.2
 jobs:
   build:
     docker:
@@ -10,6 +12,10 @@ jobs:
           path: schemas/target/surefire-reports
       - store_test_results:
           path: generator/target/surefire-reports
+      - codecov/upload:
+          file: schemas/target/jacoco-reports/jacoco.xml
+      - codecov/upload:
+          file: generator/target/jacoco-reports/jacoco.xml
 workflows:
   version: 2.1
   build_and_test: 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,10 @@
-comment: off
+comment: 
+    layout: "files"
+    require_changes: yes
+    require_base: yes
+    
+coverage:
+    status:
+        project:
+            default:
+                base: pr


### PR DESCRIPTION
### Description
Cover coverage previously provided detail of test results; however added confusion by including comments in PRs, so it was disabled. This change re-enables the reporting, but disables the introduction of comments on the PR.

### Changes
- Re-enable Codecov
- Ensure comments aren't added to PRs