### PR TITLE
Fixes to Developer Guide

### DIFF
--- a/docs/GeneratorDeveloperGuide.md
+++ b/docs/GeneratorDeveloperGuide.md
@@ -9,4 +9,4 @@
 
 1. [Contributing](../.github/CONTRIBUTING.md)
 2. [Dependency Injection](DependencyInjection.md)
-3. [Unit Testing](CucumberSyntax.md)
+3. [Integration Testing](CucumberSyntax.md)

--- a/docs/GeneratorDeveloperGuide.md
+++ b/docs/GeneratorDeveloperGuide.md
@@ -9,4 +9,4 @@
 
 1. [Contributing](../.github/CONTRIBUTING.md)
 2. [Dependency Injection](DependencyInjection.md)
-3. [Integration Testing](CucumberSyntax.md)
+3. [Cucumber Testing](CucumberSyntax.md)

--- a/docs/GeneratorDeveloperGuide.md
+++ b/docs/GeneratorDeveloperGuide.md
@@ -7,6 +7,6 @@
 
 ## Development
 
-1. [Contributing](../.github/contributing.md)
+1. [Contributing](../.github/CONTRIBUTING.md)
 2. [Dependency Injection](DependencyInjection.md)
 3. [Unit Testing](CucumberSyntax.md)


### PR DESCRIPTION
Contributing link is case sensitive and currently leads to page not found/404. Updated to link to the correct page.

Unit testing link leads to cucumber syntax guide - this is not unit testing so adjusted wording to integration testing.