### PR TITLE
#440- Separation of output data format and destination

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/commandline/GenerateCommandLine.java
@@ -103,15 +103,22 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
     private Boolean visualiseReductions = false;
 
     @CommandLine.Option(
-        names = {"-o"},
-        description = "Output format",
+        names = {"-f"},
+        description = "Format of output data",
         defaultValue = GenerationConfig.Constants.OutputFormats.DEFAULT)
     private GenerationConfig.OutputFormat outputFormat;
+
+    @CommandLine.Option(
+        names = {"-o"},
+        description = "Output destination",
+        defaultValue = GenerationConfig.Constants.Destinations.DEFAULT)
+    private GenerationConfig.OutputDestination outputDestination;
 
     @CommandLine.Option(
         names = {"--allow-untyped-fields"},
         description = "Remove the need for each field to have at least one compliant typing constraint applied")
     private boolean allowUntypedFields = false;
+
 
     public boolean shouldDoPartitioning() {
         return !this.dontPartitionTrees;
@@ -207,6 +214,11 @@ public class GenerateCommandLine extends CommandLineBase implements GenerationCo
 
     public GenerationConfig.OutputFormat getOutputFormat() {
         return outputFormat;
+    }
+
+    @Override
+    public GenerationConfig.OutputDestination getOutputDestination() {
+        return outputDestination;
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfig.java
@@ -134,6 +134,18 @@ public class GenerationConfig {
         }
     }
 
+    public enum OutputDestination {
+        STREAM(Constants.Destinations.STREAM),
+        FILE(Constants.Destinations.FILE);
+        private final String destination;
+
+        OutputDestination(String destination) { this.destination = destination; }
+
+        public String getDestination() {
+            return destination;
+        }
+    }
+
     public static class Constants {
         public static class WalkerTypes {
             public static final String CARTESIAN_PRODUCT = "CARTESIAN_PRODUCT";
@@ -170,6 +182,13 @@ public class GenerationConfig {
             public static final String JSON = "JSON";
 
             public static final String DEFAULT = CSV;
+        }
+
+        public static class Destinations {
+            public static final String STREAM = "STREAM";
+            public static final String FILE = "FILE";
+
+            public static final String DEFAULT = FILE;
         }
 
         public static final long DEFAULT_MAX_ROWS = 1000;

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/GenerationConfigSource.java
@@ -35,4 +35,5 @@ public interface GenerationConfigSource extends ConfigSource {
     boolean requireFieldTyping();
 
     GenerationConfig.OutputFormat getOutputFormat();
+    GenerationConfig.OutputDestination getOutputDestination();
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/BaseModule.java
@@ -24,11 +24,15 @@ import com.scottlogic.deg.generator.inputs.profileviolation.RuleViolator;
 import com.scottlogic.deg.generator.inputs.validation.ProfileValidator;
 import com.scottlogic.deg.generator.inputs.validation.reporters.ProfileValidationReporter;
 import com.scottlogic.deg.generator.inputs.validation.reporters.SystemOutProfileValidationReporter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.CsvFormatter;
 import com.scottlogic.deg.generator.outputs.datasetwriters.DataSetWriter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.JsonFormatter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.RowOutputFormatter;
 import com.scottlogic.deg.generator.outputs.manifest.JsonManifestWriter;
 import com.scottlogic.deg.generator.outputs.manifest.ManifestWriter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
+import com.scottlogic.deg.generator.outputs.targets.StreamOutputTarget;
 import com.scottlogic.deg.generator.utils.JavaUtilRandomNumberGenerator;
 import com.scottlogic.deg.generator.validators.ConfigValidator;
 import com.scottlogic.deg.generator.validators.GenerationConfigValidator;
@@ -65,6 +69,8 @@ public class BaseModule extends AbstractModule {
         // Bind providers - used to retrieve implementations based on user input
         bind(DecisionTreeOptimiser.class).toProvider(DecisionTreeOptimiserProvider.class);
         bind(DataSetWriter.class).toProvider(DataSetWriterProvider.class);
+        bind(RowOutputFormatter.class).toProvider(FormatterProvider.class);
+        bind(OutputTarget.class).toProvider(OutputTargetProvider.class);
         bind(TreePartitioner.class).toProvider(TreePartitioningProvider.class);
         bind(DecisionTreeWalker.class).toProvider(DecisionTreeWalkerProvider.class);
         bind(ProfileValidator.class).toProvider(ProfileValidatorProvider.class);
@@ -82,7 +88,6 @@ public class BaseModule extends AbstractModule {
         bind(ProfileValidationReporter.class).to(SystemOutProfileValidationReporter.class);
         bind(RowSpecRouteProducer.class).to(ExhaustiveProducer.class);
         bind(ProfileReader.class).to(JsonProfileReader.class);
-        bind(OutputTarget.class).to(FileOutputTarget.class);
         bind(FieldValueSourceEvaluator.class).to(StandardFieldValueSourceEvaluator.class);
         bind(ProfileViolator.class).to(IndividualRuleProfileViolator.class);
         bind(RuleViolator.class).to(IndividualConstraintRuleViolator.class);

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/FormatterProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/FormatterProvider.java
@@ -1,0 +1,34 @@
+package com.scottlogic.deg.generator.guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.outputs.datasetwriters.CsvFormatter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.JsonFormatter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.RowOutputFormatter;
+
+public class FormatterProvider implements Provider<RowOutputFormatter> {
+
+    private final GenerationConfigSource configSource;
+    private final CsvFormatter csvFormatter;
+    private final JsonFormatter jsonFormatter;
+
+    @Inject
+    public FormatterProvider(GenerationConfigSource configSource, CsvFormatter csvFormatter, JsonFormatter jsonFormatter) {
+        this.configSource = configSource;
+        this.csvFormatter = csvFormatter;
+        this.jsonFormatter = jsonFormatter;
+    }
+
+    @Override
+    public RowOutputFormatter get() {
+        switch (configSource.getOutputFormat()) {
+            case CSV:
+                return csvFormatter;
+            case JSON:
+                return jsonFormatter;
+        }
+
+        throw new RuntimeException(String.format("Unknown output format %s, options are CSV or JSON", configSource.getOutputFormat()));
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
@@ -24,6 +24,9 @@ public class MonitorProvider implements Provider<ReductiveDataGeneratorMonitor> 
 
     @Override
     public ReductiveDataGeneratorMonitor get() {
+        if (commandLine.getOutputDestination().getDestination().equals("STREAM")) {
+            return this.noopDataGeneratorMonitor;
+        }
         switch (commandLine.getMonitorType()) {
             case VERBOSE:
                 return this.systemOutDataGeneratorMonitor;

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/OutputTargetProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/OutputTargetProvider.java
@@ -1,0 +1,34 @@
+package com.scottlogic.deg.generator.guice;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
+import com.scottlogic.deg.generator.outputs.targets.OutputTarget;
+import com.scottlogic.deg.generator.outputs.targets.StreamOutputTarget;
+
+public class OutputTargetProvider implements Provider<OutputTarget> {
+
+    private final GenerationConfigSource configSource;
+    private final FileOutputTarget fileOutputTarget;
+    private final StreamOutputTarget streamOutputTarget;
+
+    @Inject
+    public OutputTargetProvider(GenerationConfigSource configSource, FileOutputTarget fileOutputTarget,
+                                StreamOutputTarget streamOutputTarget) {
+        this.configSource = configSource;
+        this.fileOutputTarget = fileOutputTarget;
+        this.streamOutputTarget = streamOutputTarget;
+    }
+
+    @Override
+    public OutputTarget get() {
+        switch (configSource.getOutputDestination()) {
+            case FILE:
+                return fileOutputTarget;
+            case STREAM:
+                return streamOutputTarget;
+        }
+        throw new RuntimeException(String.format("Unknown output destination %s, options are STREAM or FILE", configSource.getOutputDestination()));
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/OutputTargetProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/OutputTargetProvider.java
@@ -14,7 +14,8 @@ public class OutputTargetProvider implements Provider<OutputTarget> {
     private final StreamOutputTarget streamOutputTarget;
 
     @Inject
-    public OutputTargetProvider(GenerationConfigSource configSource, FileOutputTarget fileOutputTarget,
+    public OutputTargetProvider(GenerationConfigSource configSource,
+                                FileOutputTarget fileOutputTarget,
                                 StreamOutputTarget streamOutputTarget) {
         this.configSource = configSource;
         this.fileOutputTarget = fileOutputTarget;

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvDataSetWriter.java
@@ -13,9 +13,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.stream.Collectors;
 
-public class CsvDataSetWriter implements DataSetWriter<CSVPrinter> {
+public class CsvDataSetWriter implements DataSetWriter<CSVPrinter, CsvFormatter> {
     private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
     private static final CSVFormat writerFormat = CSVFormat.RFC4180;
     private static final CSVFormat csvStringFormatter = writerFormat.withQuoteMode(QuoteMode.ALL);
@@ -32,11 +31,8 @@ public class CsvDataSetWriter implements DataSetWriter<CSVPrinter> {
                 StandardCharsets.UTF_8);
     }
 
-    public void writeRow(CSVPrinter writer, GeneratedObject row) throws IOException {
-        writer.printRecord(row.values.stream()
-            .map(CsvDataSetWriter::extractCellValue)
-            .map(CsvDataSetWriter::wrapInQuotesIfString)
-            .collect(Collectors.toList()));
+    public void writeRow(CSVPrinter writer, GeneratedObject row, CsvFormatter formatter) throws IOException {
+        writer.printRecord(formatter.format(row));
 
         writer.flush();
     }
@@ -44,29 +40,5 @@ public class CsvDataSetWriter implements DataSetWriter<CSVPrinter> {
     @Override
     public String getFileName(String fileNameWithoutExtension) {
         return fileNameWithoutExtension + ".csv";
-    }
-
-    private static Object extractCellValue(DataBagValue cell) {
-        return cell.getFormattedValue();
-    }
-
-    private static Object wrapInQuotesIfString(Object value){
-        if (value == null){
-            return null;
-        }
-
-        if (value instanceof BigDecimal) {
-            return ((BigDecimal) value).toPlainString();
-        }
-
-        if (value instanceof OffsetDateTime){
-            return standardDateFormat.format((OffsetDateTime) value);
-        }
-
-        if (value instanceof String){
-            return csvStringFormatter.format(value);
-        }
-
-        return value;
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvDataSetWriter.java
@@ -13,12 +13,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
-public class CsvDataSetWriter implements DataSetWriter<CSVPrinter, CsvFormatter> {
-    private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+public class CsvDataSetWriter implements DataSetWriter<CSVPrinter, List<Object>> {
     private static final CSVFormat writerFormat = CSVFormat.RFC4180;
-    private static final CSVFormat csvStringFormatter = writerFormat.withQuoteMode(QuoteMode.ALL);
 
+    @Override
     public CSVPrinter openWriter(Path directory, String fileName, ProfileFields profileFields) throws IOException {
         return writerFormat
             .withEscape('\0') //Dont escape any character, we're formatting strings ourselves
@@ -31,7 +31,8 @@ public class CsvDataSetWriter implements DataSetWriter<CSVPrinter, CsvFormatter>
                 StandardCharsets.UTF_8);
     }
 
-    public void writeRow(CSVPrinter writer, GeneratedObject row, CsvFormatter formatter) throws IOException {
+    @Override
+    public void writeRow(CSVPrinter writer, GeneratedObject row, RowOutputFormatter<List<Object>> formatter) throws IOException {
         writer.printRecord(formatter.format(row));
 
         writer.flush();

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvFormatter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/CsvFormatter.java
@@ -1,0 +1,50 @@
+package com.scottlogic.deg.generator.outputs.datasetwriters;
+
+import com.scottlogic.deg.generator.generation.databags.DataBagValue;
+import com.scottlogic.deg.generator.outputs.GeneratedObject;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.QuoteMode;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CsvFormatter implements RowOutputFormatter<List<Object>> {
+    private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+    private static final CSVFormat writerFormat = CSVFormat.RFC4180;
+    private static final CSVFormat csvStringFormatter = writerFormat.withQuoteMode(QuoteMode.ALL);
+
+    @Override
+    public List<Object> format(GeneratedObject row) {
+        return row.values.stream()
+            .map(CsvFormatter::extractCellValue)
+            .map(CsvFormatter::wrapInQuotesIfString)
+            .collect(Collectors.toList());
+    }
+
+    private static Object extractCellValue(DataBagValue cell) {
+        return cell.getFormattedValue();
+    }
+
+    private static Object wrapInQuotesIfString(Object value){
+        if (value == null){
+            return null;
+        }
+
+        if (value instanceof BigDecimal) {
+            return ((BigDecimal) value).toPlainString();
+        }
+
+        if (value instanceof OffsetDateTime){
+            return standardDateFormat.format((OffsetDateTime) value);
+        }
+
+        if (value instanceof String){
+            return csvStringFormatter.format(value);
+        }
+
+        return value;
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/DataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/DataSetWriter.java
@@ -7,13 +7,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public interface DataSetWriter<TWriter extends Closeable, C> {
+public interface DataSetWriter<TWriter extends Closeable, T> {
     TWriter openWriter(
         Path directory,
         String fileName,
         ProfileFields profileFields) throws IOException;
 
-    void writeRow(TWriter writer, GeneratedObject row, C formatter) throws IOException;
+    void writeRow(TWriter writer, GeneratedObject row, RowOutputFormatter<T> formatter) throws IOException;
 
     String getFileName(String fileNameWithoutExtension);
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/DataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/DataSetWriter.java
@@ -7,13 +7,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public interface DataSetWriter<TWriter extends Closeable> {
+public interface DataSetWriter<TWriter extends Closeable, C> {
     TWriter openWriter(
         Path directory,
         String fileName,
         ProfileFields profileFields) throws IOException;
 
-    void writeRow(TWriter writer, GeneratedObject row) throws IOException;
+    void writeRow(TWriter writer, GeneratedObject row, C formatter) throws IOException;
 
     String getFileName(String fileNameWithoutExtension);
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonDataSetWriter.java
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
-public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWriter> {
+public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWriter, JsonFormatter> {
     private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ofPattern("dd-MM-yyyy hh:mm:ss");
 
     @Override
@@ -32,7 +32,7 @@ public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWr
     }
 
     @Override
-    public void writeRow(JsonDataSetWriter.JsonWriter writer, GeneratedObject row) {
+    public void writeRow(JsonDataSetWriter.JsonWriter writer, GeneratedObject row, JsonFormatter formatter) {
         //TODO: Change this type to write progressively to the JSON file, currently it holds all rows in memory: Issue: #256
 
         ObjectNode rowNode = writer.jsonObjectMapper.createObjectNode();

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonDataSetWriter.java
@@ -18,7 +18,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
-public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWriter, JsonFormatter> {
+public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWriter, String> {
     private static final DateTimeFormatter standardDateFormat = DateTimeFormatter.ofPattern("dd-MM-yyyy hh:mm:ss");
 
     @Override
@@ -32,7 +32,7 @@ public class JsonDataSetWriter implements DataSetWriter<JsonDataSetWriter.JsonWr
     }
 
     @Override
-    public void writeRow(JsonDataSetWriter.JsonWriter writer, GeneratedObject row, JsonFormatter formatter) {
+    public void writeRow(JsonDataSetWriter.JsonWriter writer, GeneratedObject row, RowOutputFormatter<String> formatter) {
         //TODO: Change this type to write progressively to the JSON file, currently it holds all rows in memory: Issue: #256
 
         ObjectNode rowNode = writer.jsonObjectMapper.createObjectNode();

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonFormatter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/JsonFormatter.java
@@ -1,0 +1,28 @@
+package com.scottlogic.deg.generator.outputs.datasetwriters;
+
+import com.scottlogic.deg.generator.outputs.GeneratedObject;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+
+public class JsonFormatter implements RowOutputFormatter<String> {
+
+    @Override
+    public String format(GeneratedObject row) {
+        ArrayList<String> strValue = new ArrayList<>();
+
+        for (int i = 0; i < row.values.size(); i++) {
+            String field = row.source.columns.get(i).field.toString();
+            String value = Optional
+                .ofNullable(row.values.get(i).getFormattedValue()).orElse("null")
+                .toString();
+
+            String desiredFormat = String.format("%s: %s", field, value);
+
+            strValue.add(desiredFormat);
+        }
+
+        return String.format("{%s}", strValue.toString().substring(1, strValue.toString().length()-1));
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/MultiDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/MultiDataSetWriter.java
@@ -9,7 +9,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class MultiDataSetWriter implements DataSetWriter<Closeable> {
+public class MultiDataSetWriter implements DataSetWriter<Closeable, RowOutputFormatter> {
     private final List<StatefulDataSetWriter> writers;
 
     public MultiDataSetWriter(DataSetWriter... writers) {
@@ -33,12 +33,12 @@ public class MultiDataSetWriter implements DataSetWriter<Closeable> {
     }
 
     @Override
-    public void writeRow(Closeable closeable, GeneratedObject row) throws IOException {
+    public void writeRow(Closeable closeable, GeneratedObject row, RowOutputFormatter formatter) throws IOException {
         ThrownExceptions exceptions = new ThrownExceptions();
 
         this.writers.forEach(writer -> {
             try {
-                writer.writeRow(row);
+                writer.writeRow(row, formatter);
             } catch (IOException e) {
                 exceptions.add(e);
             }
@@ -111,12 +111,12 @@ public class MultiDataSetWriter implements DataSetWriter<Closeable> {
             this.closeable = this.writer.openWriter(directory, this.fileName, profileFields);
         }
 
-        void writeRow(GeneratedObject row) throws IOException {
+        void writeRow(GeneratedObject row, RowOutputFormatter formatter) throws IOException {
             if (this.closeable == null){
                 throw new IllegalStateException("Writer has not been initialised");
             }
 
-            this.writer.writeRow(this.closeable, row);
+            this.writer.writeRow(this.closeable, row, formatter);
         }
 
         String getFileNameAndRemember(String fileNameWithoutExtension) {

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/RowOutputFormatter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/RowOutputFormatter.java
@@ -1,0 +1,9 @@
+package com.scottlogic.deg.generator.outputs.datasetwriters;
+
+import com.scottlogic.deg.generator.outputs.GeneratedObject;
+
+@FunctionalInterface
+public interface RowOutputFormatter<T> {
+
+    T format(GeneratedObject row);
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/SourceTracingDataSetWriter.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/datasetwriters/SourceTracingDataSetWriter.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class SourceTracingDataSetWriter implements DataSetWriter<SourceTracingDataSetWriter.JsonArrayOutputWriter> {
+public class SourceTracingDataSetWriter implements DataSetWriter<SourceTracingDataSetWriter.JsonArrayOutputWriter, RowOutputFormatter> {
     private final ObjectWriter writer;
 
     public SourceTracingDataSetWriter() {
@@ -37,7 +37,7 @@ public class SourceTracingDataSetWriter implements DataSetWriter<SourceTracingDa
     }
 
     @Override
-    public void writeRow(JsonArrayOutputWriter closeable, GeneratedObject row) throws IOException {
+    public void writeRow(JsonArrayOutputWriter closeable, GeneratedObject row, RowOutputFormatter formatter) throws IOException {
         Collection<TracingDto> dto = row.source != null
             ? TracingDto.fromRowSource(row.source)
             : TracingDto.empty;

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/FileOutputTarget.java
@@ -5,9 +5,11 @@ import com.google.inject.name.Named;
 import com.scottlogic.deg.generator.ProfileFields;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.outputs.datasetwriters.DataSetWriter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.RowOutputFormatter;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
@@ -15,11 +17,13 @@ import java.util.stream.Stream;
 public class FileOutputTarget implements OutputTarget{
     private final Path filePath;
     private final DataSetWriter dataSetWriter;
+    private final RowOutputFormatter formatter;
 
     @Inject
-    public FileOutputTarget(@Named("outputPath") Path filePath, DataSetWriter dataSetWriter) {
+    public FileOutputTarget(@Named("outputPath") Path filePath, DataSetWriter dataSetWriter, RowOutputFormatter formatter) {
         this.filePath = filePath;
         this.dataSetWriter = dataSetWriter;
+        this.formatter = formatter;
     }
 
     @Override
@@ -39,9 +43,9 @@ public class FileOutputTarget implements OutputTarget{
         try (Closeable writer = this.dataSetWriter.openWriter(directoryPath, fileName, profileFields)) {
             generatedObjects.forEach(row -> {
                 try {
-                    this.dataSetWriter.writeRow(writer, row);
+                    this.dataSetWriter.writeRow(writer, row, formatter);
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             });
         }
@@ -50,7 +54,8 @@ public class FileOutputTarget implements OutputTarget{
     public FileOutputTarget withFilename(String filename){
         return new FileOutputTarget(
             filePath.resolve(dataSetWriter.getFileName(filename)),
-            dataSetWriter);
+            dataSetWriter,
+            formatter);
     }
 
     public Path getFilePath() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/StreamOutputTarget.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/outputs/targets/StreamOutputTarget.java
@@ -1,0 +1,23 @@
+package com.scottlogic.deg.generator.outputs.targets;
+
+import com.google.inject.Inject;
+import com.scottlogic.deg.generator.ProfileFields;
+import com.scottlogic.deg.generator.outputs.GeneratedObject;
+import com.scottlogic.deg.generator.outputs.datasetwriters.RowOutputFormatter;
+
+import java.util.stream.Stream;
+
+public class StreamOutputTarget implements OutputTarget {
+
+    private final RowOutputFormatter formatter;
+
+    @Inject
+    public StreamOutputTarget(RowOutputFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Override
+    public void outputDataset(Stream<GeneratedObject> generatedObjects, ProfileFields profileFields) {
+        generatedObjects.forEach(row -> System.out.println(formatter.format(row)));
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -107,4 +107,9 @@ public class CucumberGenerationConfigSource implements GenerationConfigSource {
     public GenerationConfig.OutputFormat getOutputFormat() {
         return null;
     }
+
+    @Override
+    public GenerationConfig.OutputDestination getOutputDestination() {
+        return null;
+    }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -110,6 +110,6 @@ public class CucumberGenerationConfigSource implements GenerationConfigSource {
 
     @Override
     public GenerationConfig.OutputDestination getOutputDestination() {
-        return null;
+        return state.outputDestination;
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestState.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/cucumber/testframework/utils/CucumberTestState.java
@@ -18,6 +18,7 @@ public class CucumberTestState {
     public GenerationConfig.DataGenerationType dataGenerationType;
     public GenerationConfig.CombinationStrategyType combinationStrategyType = GenerationConfig.CombinationStrategyType.PINNING;
     public GenerationConfig.TreeWalkerType walkerType = GenerationConfig.TreeWalkerType.REDUCTIVE;
+    public GenerationConfig.OutputDestination outputDestination = GenerationConfig.OutputDestination.FILE;
 
     /**
      * Boolean to represent if the generation mode is validating or violating.

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/TestGenerationConfigSource.java
@@ -16,6 +16,7 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     public boolean validateProfile = false;
     public Path outputPath;
     public GenerationConfig.OutputFormat outputFormat = GenerationConfig.OutputFormat.CSV;
+    public GenerationConfig.OutputDestination outputDestination = GenerationConfig.OutputDestination.FILE;
     public boolean requireFieldTyping = true;
 
     public TestGenerationConfigSource(
@@ -121,5 +122,10 @@ public class TestGenerationConfigSource implements GenerationConfigSource {
     @Override
     public GenerationConfig.OutputFormat getOutputFormat() {
         return outputFormat;
+    }
+
+    @Override
+    public GenerationConfig.OutputDestination getOutputDestination() {
+        return outputDestination;
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/outputs/CsvDataSetWriterTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/outputs/CsvDataSetWriterTests.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.generator.outputs;
 import com.scottlogic.deg.generator.generation.databags.DataBagValue;
 import com.scottlogic.deg.generator.DataBagValueSource;
 import com.scottlogic.deg.generator.outputs.datasetwriters.CsvDataSetWriter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.CsvFormatter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
@@ -26,9 +27,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValue(new BigDecimal("0.00000001"))),
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("0.00000001", stringBuffer.toString().trim());
@@ -42,9 +44,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValueWithFormat(new BigDecimal("0.00000001"), "%.1e")), // Formats the bigDecimal into Scientific notation
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("\"1.0e-08\"", stringBuffer.toString().trim());
@@ -58,9 +61,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValue(null)),
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("", stringBuffer.toString().trim());
@@ -74,9 +78,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(new DataBagValue(1.2f, DataBagValueSource.Empty)),
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("1.2", stringBuffer.toString().trim());
@@ -90,9 +95,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValueWithFormat("Hello World", "%.5s")), // Format string to max 5 chars
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("\"Hello\"", stringBuffer.toString().trim());
@@ -107,9 +113,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValue(date)), // Format string to max 5 chars
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("2001-02-03T04:05:06Z", stringBuffer.toString().trim());
@@ -124,9 +131,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValue(date)), // Format string to max 5 chars
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("2001-02-03T04:05:06.777Z", stringBuffer.toString().trim());
@@ -141,9 +149,10 @@ public class CsvDataSetWriterTests {
             Collections.singletonList(getValueWithFormat(date, "%tF")), // Format string to max 5 chars
             new RowSource(Collections.emptyList()));
         CSVPrinter printer = new CSVPrinter(stringBuffer, format);
+        CsvFormatter csvFormatter = new CsvFormatter();
 
         // Act
-        writeToBuffer(printer, generatedObject);
+        writeToBuffer(printer, generatedObject, csvFormatter);
 
         // Assert
         Assert.assertEquals("\"2001-02-03\"", stringBuffer.toString().trim());
@@ -157,9 +166,9 @@ public class CsvDataSetWriterTests {
         return new DataBagValue(value, format, DataBagValueSource.Empty);
     }
 
-    private void writeToBuffer(CSVPrinter printer, GeneratedObject generatedObject) throws IOException {
+    private void writeToBuffer(CSVPrinter printer, GeneratedObject generatedObject, CsvFormatter formatter) throws IOException {
         CsvDataSetWriter writer = new CsvDataSetWriter();
-        writer.writeRow(printer, generatedObject);
+        writer.writeRow(printer, generatedObject, formatter);
         printer.close();
     }
 }

--- a/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/smoke_tests/ExampleProfilesViolationTests.java
@@ -20,6 +20,7 @@ import com.scottlogic.deg.generator.inputs.profileviolation.IndividualConstraint
 import com.scottlogic.deg.generator.inputs.profileviolation.IndividualRuleProfileViolator;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.outputs.datasetwriters.DataSetWriter;
+import com.scottlogic.deg.generator.outputs.datasetwriters.RowOutputFormatter;
 import com.scottlogic.deg.generator.outputs.targets.FileOutputTarget;
 import com.scottlogic.deg.generator.reducer.ConstraintReducer;
 import com.scottlogic.deg.generator.restrictions.StringRestrictionsFactory;
@@ -145,7 +146,7 @@ class ExampleProfilesViolationTests {
 
     private class NullOutputTarget extends FileOutputTarget {
         NullOutputTarget() {
-            super(null, new NullDataSetWriter());
+            super(null, new NullDataSetWriter(), new NullFormatter());
         }
 
         @Override
@@ -162,18 +163,25 @@ class ExampleProfilesViolationTests {
         }
     }
 
-    private class NullDataSetWriter implements DataSetWriter{
+    private class NullDataSetWriter implements DataSetWriter<Closeable, RowOutputFormatter>{
         @Override
         public Closeable openWriter(Path directory, String filenameWithoutExtension, ProfileFields profileFields) {
             return null;
         }
 
         @Override
-        public void writeRow(Closeable closeable, GeneratedObject row) {
+        public void writeRow(Closeable closeable, GeneratedObject row, RowOutputFormatter formatter) {
         }
 
         @Override
         public String getFileName(String fileNameWithoutExtension) {
+            return null;
+        }
+    }
+
+    private class NullFormatter implements RowOutputFormatter {
+        @Override
+        public Object format(GeneratedObject row) {
             return null;
         }
     }


### PR DESCRIPTION
### Description
This PR introduces the ability to write the generated data to `stdout` instead of a file. To achieve this the formatting of the data and where it should be sent are separated. This means that now you can specify which format of the data you want i.e JSON or CSV, and then specify separately whether you want to write this format to `stdout` or to a file. 

### Changes
- Added new `RowOutputFormatter` interface with JSON and CSV implementations
- Added new `outputTarget` implementation for streaming to `stdout`
- Added `-f` switch to commandline to represent output data format. Options are JSON or CSV currently
- Updated `-o` switch to only decide on the data's destination. Options are FILE or STREAM currently

### Additional notes
I have tried to implement the [bridge](https://en.wikipedia.org/wiki/Bridge_pattern) pattern within this PR, so that in the future the number of formats can grow independently of the output destinations. This has almost been achieved, except for the following caveat: if the user wants to add a new data format and write to a file, a new `dataSetWriter` will also have to be created.
Also, it should be noted that without using the additional switches the functionality of the generator has not been modified.

Relates to #440