### PR TITLE
Make monitors destination-agnostic

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/DataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/DataGeneratorMonitor.java
@@ -3,8 +3,7 @@ package com.scottlogic.deg.generator.generation;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 
 public interface DataGeneratorMonitor {
-    void generationStarting();
-    void rowEmitted(GeneratedObject row);
-    void endGeneration();
+    default void generationStarting() {}
+    default void rowEmitted(GeneratedObject row) {}
+    default void endGeneration() {}
 }
-

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
@@ -1,7 +1,6 @@
 package com.scottlogic.deg.generator.generation;
 
 import com.scottlogic.deg.common.profile.Field;
-import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
@@ -17,18 +16,6 @@ public class MessagePrintingDataGeneratorMonitor implements ReductiveDataGenerat
 
     public MessagePrintingDataGeneratorMonitor(PrintWriter writer) {
         this.writer = writer;
-    }
-
-    @Override
-    public void generationStarting() {
-    }
-
-    @Override
-    public void rowEmitted(GeneratedObject row) {
-    }
-
-    @Override
-    public void endGeneration() {
     }
 
     private void println(String message) {
@@ -80,4 +67,3 @@ public class MessagePrintingDataGeneratorMonitor implements ReductiveDataGenerat
             Objects.toString(emptyFieldSpecs));
     }
 }
-

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/MessagePrintingDataGeneratorMonitor.java
@@ -6,12 +6,18 @@ import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
 import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class SystemOutDataGeneratorMonitor implements ReductiveDataGeneratorMonitor {
+public class MessagePrintingDataGeneratorMonitor implements ReductiveDataGeneratorMonitor {
+    private final PrintWriter writer;
+
+    public MessagePrintingDataGeneratorMonitor(PrintWriter writer) {
+        this.writer = writer;
+    }
 
     @Override
     public void generationStarting() {
@@ -25,33 +31,40 @@ public class SystemOutDataGeneratorMonitor implements ReductiveDataGeneratorMoni
     public void endGeneration() {
     }
 
+    private void println(String message) {
+        writer.println(message);
+    }
+
+    private void println(String message, Object... args) {
+        writer.format(message, args);
+        writer.println();
+    }
+
     @Override
     public void rowSpecEmitted(RowSpec rowSpec) {
-        System.out.println("RowSpec emitted");
+        println("RowSpec emitted");
     }
 
     @Override
     public void fieldFixedToValue(Field field, Object current) {
-        System.out.println(String.format("Field [%s] = %s", field.name, current));
+        println("Field [%s] = %s", field.name, current);
     }
 
     @Override
     public void unableToStepFurther(ReductiveState reductiveState) {
-        System.out.println(
-            String.format(
-                "%d: Unable to step further %s ",
-                reductiveState.getFieldValues().size(),
-                reductiveState.toString(true)));
+        println(
+            "%d: Unable to step further %s ",
+            reductiveState.getFieldValues().size(),
+            reductiveState.toString(true));
     }
 
     @Override
     public void noValuesForField(ReductiveState reductiveState, Field field) {
-        System.out.println(
-            String.format(
-                "%d: No values for field %s: %s ",
-                reductiveState.getFieldValues().size(),
-                field,
-                reductiveState.toString(true)));
+        println(
+            "%d: No values for field %s: %s ",
+            reductiveState.getFieldValues().size(),
+            field,
+            reductiveState.toString(true));
     }
 
     @Override
@@ -61,11 +74,10 @@ public class SystemOutDataGeneratorMonitor implements ReductiveDataGeneratorMoni
             .filter(entry -> entry.getValue() == FieldSpec.Empty)
             .collect(Collectors.toList());
 
-        System.out.println(
-            String.format(
-                "%d: Unable to emit row, some FieldSpec's are Empty: %s",
-                reductiveState.getFieldValues().size(),
-                Objects.toString(emptyFieldSpecs)));
+        println(
+            "%d: Unable to emit row, some FieldSpecs are Empty: %s",
+            reductiveState.getFieldValues().size(),
+            Objects.toString(emptyFieldSpecs));
     }
 }
 

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/NoopDataGeneratorMonitor.java
@@ -1,36 +1,5 @@
 package com.scottlogic.deg.generator.generation;
 
-import com.scottlogic.deg.common.profile.Field;
-import com.scottlogic.deg.generator.outputs.GeneratedObject;
-import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
-import com.scottlogic.deg.generator.fieldspecs.RowSpec;
-import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
-
-import java.util.Map;
-
 public class NoopDataGeneratorMonitor implements ReductiveDataGeneratorMonitor {
-
-    @Override
-    public void generationStarting() { }
-
-    @Override
-    public void rowEmitted(GeneratedObject row) { }
-
-    @Override
-    public void endGeneration() { }
-
-    @Override
-    public void rowSpecEmitted(RowSpec rowSpec) { }
-
-    @Override
-    public void fieldFixedToValue(Field field, Object current) { }
-
-    @Override
-    public void unableToStepFurther(ReductiveState reductiveState) { }
-
-    @Override
-    public void noValuesForField(ReductiveState reductiveState, Field field) { }
-
-    @Override
-    public void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField) { }
+    // don't override any of the default no-op implementations from the interface
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
@@ -7,10 +7,10 @@ import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
 import java.util.Map;
 
-public interface ReductiveDataGeneratorMonitor extends DataGeneratorMonitor{
+public interface ReductiveDataGeneratorMonitor extends DataGeneratorMonitor {
     void rowSpecEmitted(RowSpec rowSpec);
     void fieldFixedToValue(Field field, Object current);
     void unableToStepFurther(ReductiveState reductiveState);
     void noValuesForField(ReductiveState reductiveState, Field field);
     void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField);
-    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/ReductiveDataGeneratorMonitor.java
@@ -8,9 +8,9 @@ import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 import java.util.Map;
 
 public interface ReductiveDataGeneratorMonitor extends DataGeneratorMonitor {
-    void rowSpecEmitted(RowSpec rowSpec);
-    void fieldFixedToValue(Field field, Object current);
-    void unableToStepFurther(ReductiveState reductiveState);
-    void noValuesForField(ReductiveState reductiveState, Field field);
-    void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField);
+    default void rowSpecEmitted(RowSpec rowSpec) {}
+    default void fieldFixedToValue(Field field, Object current) {}
+    default void unableToStepFurther(ReductiveState reductiveState) {}
+    default void noValuesForField(ReductiveState reductiveState, Field field) {}
+    default void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField) {}
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
@@ -6,6 +6,7 @@ import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
 import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
+import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
@@ -28,15 +29,21 @@ public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
     private DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private long previousVelocity = 0;
 
+    private final PrintWriter writer;
+
+    public VelocityMonitor(PrintWriter writer) {
+        this.writer = writer;
+    }
+
     @Override
     public void generationStarting() {
         startedGenerating = OffsetDateTime.now(ZoneOffset.UTC);
         rowsSinceLastSample = 0;
         rowsEmitted = BigInteger.ZERO;
 
-        System.out.println("Generation started at: " + timeFormatter.format(startedGenerating) + "\n");
-        System.out.println("Number of rows | Velocity (rows/sec) | Velocity trend");
-        System.out.println("---------------+---------------------+---------------");
+        println("Generation started at: " + timeFormatter.format(startedGenerating) + "\n");
+        println("Number of rows | Velocity (rows/sec) | Velocity trend");
+        println("---------------+---------------------+---------------");
 
         timer = new Timer(true);
         timer.scheduleAtFixedRate(new TimerTask() {
@@ -77,28 +84,33 @@ public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
             .divide(totalMilliseconds, RoundingMode.HALF_UP)
             .multiply(millisecondsInSecond).toBigInteger();
 
-        System.out.println(String.format(
+        println(
             "%-14s | %-19d | Finished",
             rowsEmitted.toString(),
-            averageRowsPerSecond
-        ));
+            averageRowsPerSecond);
 
-        System.out.println(
-            String.format(
-                "\nGeneration finished at: %s",
-                timeFormatter.format(finished)));
+        println(
+            "\nGeneration finished at: %s",
+            timeFormatter.format(finished));
     }
 
     private void reportVelocity(long rowsSinceLastSample) {
         String trend = rowsSinceLastSample > previousVelocity ? "+" : "-";
-        System.out.println(
-        String.format(
+        println(
             "%-14s | %-19d | %s",
             rowsEmitted.toString(),
             rowsSinceLastSample,
-            trend)
-        );
+            trend);
         previousVelocity = rowsSinceLastSample;
+    }
+
+    private void println(String message) {
+        writer.println(message);
+    }
+
+    private void println(String message, Object... args) {
+        writer.format(message, args);
+        writer.println();
     }
 
     @Override

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/VelocityMonitor.java
@@ -1,10 +1,6 @@
 package com.scottlogic.deg.generator.generation;
 
-import com.scottlogic.deg.common.profile.Field;
-import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
-import com.scottlogic.deg.generator.fieldspecs.RowSpec;
 import com.scottlogic.deg.generator.outputs.GeneratedObject;
-import com.scottlogic.deg.generator.walker.reductive.ReductiveState;
 
 import java.io.PrintWriter;
 import java.math.BigDecimal;
@@ -14,7 +10,6 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -111,30 +106,5 @@ public class VelocityMonitor implements ReductiveDataGeneratorMonitor {
     private void println(String message, Object... args) {
         writer.format(message, args);
         writer.println();
-    }
-
-    @Override
-    public void rowSpecEmitted(RowSpec rowSpec) {
-
-    }
-
-    @Override
-    public void fieldFixedToValue(Field field, Object current) {
-
-    }
-
-    @Override
-    public void unableToStepFurther(ReductiveState reductiveState) {
-
-    }
-
-    @Override
-    public void noValuesForField(ReductiveState reductiveState, Field field) {
-
-    }
-
-    @Override
-    public void unableToEmitRowAsSomeFieldSpecsAreEmpty(ReductiveState reductiveState, Map<Field, FieldSpec> fieldSpecsPerField) {
-
     }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/BaseModule.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/BaseModule.java
@@ -88,9 +88,7 @@ public class BaseModule extends AbstractModule {
         bind(new TypeLiteral<List<ViolationFilter>>() {
         }).toProvider(ViolationFiltersProvider.class);
 
-        bind(VelocityMonitor.class).in(Singleton.class);
         bind(JavaUtilRandomNumberGenerator.class).toInstance(new JavaUtilRandomNumberGenerator(OffsetDateTime.now().getNano()));
-
     }
 
     private void bindAllCommandLineTypes() {

--- a/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/guice/MonitorProvider.java
@@ -4,35 +4,34 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.scottlogic.deg.generator.generation.*;
 
-public class MonitorProvider implements Provider<ReductiveDataGeneratorMonitor>  {
+import java.io.PrintWriter;
 
+public class MonitorProvider implements Provider<ReductiveDataGeneratorMonitor>  {
     private GenerationConfigSource commandLine;
-    private VelocityMonitor velocityMonitor;
     private NoopDataGeneratorMonitor noopDataGeneratorMonitor;
-    private SystemOutDataGeneratorMonitor systemOutDataGeneratorMonitor;
 
     @Inject
-    MonitorProvider(GenerationConfigSource commandLine,
-                    VelocityMonitor velocityMonitor,
-                    NoopDataGeneratorMonitor noopDataGeneratorMonitor,
-                    SystemOutDataGeneratorMonitor systemOutDataGeneratorMonitor) {
+    MonitorProvider(
+        GenerationConfigSource commandLine,
+        NoopDataGeneratorMonitor noopDataGeneratorMonitor) {
+
         this.commandLine = commandLine;
-        this.velocityMonitor = velocityMonitor;
         this.noopDataGeneratorMonitor = noopDataGeneratorMonitor;
-        this.systemOutDataGeneratorMonitor = systemOutDataGeneratorMonitor;
     }
 
     @Override
     public ReductiveDataGeneratorMonitor get() {
         switch (commandLine.getMonitorType()) {
             case VERBOSE:
-                return this.systemOutDataGeneratorMonitor;
+                return new MessagePrintingDataGeneratorMonitor(
+                    new PrintWriter(System.out, true));
 
             case QUIET:
                 return this.noopDataGeneratorMonitor;
 
             default:
-                return this.velocityMonitor;
+                return new VelocityMonitor(
+                    new PrintWriter(System.out, true));
         }
     }
 }


### PR DESCRIPTION
Some monitors print to stdout. Prior to this change, they directly reference `System.out`. This change makes them consume a PrintWriter, so they can (separately to this change) write to stderr instead in the case where stdout is being used for streaming generated data.