### PR TITLE
Make RegexStringGenerator print to stderr instead of stdout

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/RegexStringGenerator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/RegexStringGenerator.java
@@ -152,7 +152,7 @@ public class RegexStringGenerator implements StringGenerator {
                 ? Collections.singleton(shortestString)
                 : Arrays.asList(shortestString, longestString);
         } catch (Exception e) {
-            System.out.println(
+            System.err.println(
                 String.format(
                     "Unable to generate interesting strings for %s\n%s",
                     this.regexRepresentation,


### PR DESCRIPTION
This code is already dubious:

```
try {
	String shortestString = AutomatonUtils.getShortestExample(automaton);
	String longestString = AutomatonUtils.getLongestExample(automaton);

	return shortestString.equals(longestString)
		? Collections.singleton(shortestString)
		: Arrays.asList(shortestString, longestString);
} catch (Exception e) {
	System.out.println(
		String.format(
			"Unable to generate interesting strings for %s\n%s",
			this.regexRepresentation,
			e.getMessage()));

	return Collections.emptySet();
}
```

but replacing `System.out` with `System.err` makes it 5% less dubious and removes a case where it could foul up generating to stdout (see #440).