### PR TITLE
Fixed bug with allOf and added support for --allow-untyped-fields in cucumber

### DIFF
--- a/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/MultipleProfileValidator.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/inputs/validation/MultipleProfileValidator.java
@@ -2,10 +2,15 @@ package com.scottlogic.deg.generator.inputs.validation;
 
 import com.scottlogic.deg.common.profile.Profile;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 public class MultipleProfileValidator implements ProfileValidator{
     private final Collection<ProfileValidator> validators;
+
+    public MultipleProfileValidator() {
+        this.validators = new ArrayList<>();
+    }
 
     public MultipleProfileValidator(Collection<ProfileValidator> validators) {
         this.validators = validators;

--- a/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictions.java
@@ -59,12 +59,6 @@ public class DataTypeRestrictions implements TypeRestrictions {
         if (allowedTypes.isEmpty())
             return null;
 
-        //micro-optimisation; if there is only one value in allowedTypes then there must have been only one value in either this.allowedTypes or other.allowedTypes
-        if (allowedTypes.size() == 1) {
-            return other.getAllowedTypes().size() == 1
-                    ? other
-                    : this;
-        }
 
         return new DataTypeRestrictions(allowedTypes);
     }

--- a/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictionsTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/restrictions/DataTypeRestrictionsTests.java
@@ -4,7 +4,12 @@ import com.scottlogic.deg.common.profile.constraints.atomic.IsOfTypeConstraint;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DataTypeRestrictionsTests {
     @Test
@@ -51,5 +56,49 @@ class DataTypeRestrictionsTests {
         TypeRestrictions result = exceptStrings.except(IsOfTypeConstraint.Types.DATETIME);
 
         Assert.assertThat(result.getAllowedTypes(), empty());
+    }
+
+    @Test
+    public void intersect_withAllPermittedTypes_shouldReturnSelf(){
+        Collection<IsOfTypeConstraint.Types> allowedTypes = new ArrayList<>();
+        allowedTypes.add(IsOfTypeConstraint.Types.STRING);
+        allowedTypes.add(IsOfTypeConstraint.Types.DATETIME);
+        DataTypeRestrictions self = new DataTypeRestrictions(allowedTypes);
+
+        TypeRestrictions actual = self.intersect(DataTypeRestrictions.ALL_TYPES_PERMITTED);
+
+        assertEquals(self, actual);
+    }
+
+    @Test
+    public void intersect_withNoPermittedTypes_shouldReturnNull(){
+        Collection<IsOfTypeConstraint.Types> allowedTypes = new ArrayList<>();
+        allowedTypes.add(IsOfTypeConstraint.Types.STRING);
+        allowedTypes.add(IsOfTypeConstraint.Types.DATETIME);
+        DataTypeRestrictions self = new DataTypeRestrictions(allowedTypes);
+
+        TypeRestrictions actual = self.intersect(DataTypeRestrictions.NO_TYPES_PERMITTED);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void intersect_withSomePermittedTypes_shouldReturnIntersection(){
+        Collection<IsOfTypeConstraint.Types> allowedTypes = new ArrayList<>();
+        allowedTypes.add(IsOfTypeConstraint.Types.STRING);
+        allowedTypes.add(IsOfTypeConstraint.Types.DATETIME);
+        DataTypeRestrictions self = new DataTypeRestrictions(allowedTypes);
+
+        Collection<IsOfTypeConstraint.Types> otherAllowedTypes = new ArrayList<>();
+        otherAllowedTypes.add(IsOfTypeConstraint.Types.NUMERIC);
+        otherAllowedTypes.add(IsOfTypeConstraint.Types.STRING);
+        DataTypeRestrictions other = new DataTypeRestrictions(otherAllowedTypes);
+
+        TypeRestrictions actual = self.intersect(other);
+
+        Collection<IsOfTypeConstraint.Types> expectedAllowedTypes = new ArrayList<>();
+        expectedAllowedTypes.add(IsOfTypeConstraint.Types.STRING);
+        DataTypeRestrictions expected = new DataTypeRestrictions(expectedAllowedTypes);
+        assertEquals(expected, actual);
     }
 }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/Violation.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/Violation.feature
@@ -138,3 +138,17 @@ Feature: The violations mode of the Data Helix app can be run in violations mode
     Then 5 rows of data are generated
     And foo contains string data
     And foo contains strings matching /[a-z]{0,9}/
+
+  Scenario: The generator should produce correct violating data for anyOf construction
+    Given there is a constraint:
+      """
+      { "anyOf": [
+        { "field": "foo", "is": "ofType", "value": "string" },
+        { "field": "foo", "is": "ofType", "value": "decimal" }
+      ]}
+      """
+    And the generation strategy is random
+    And the data requested is violating
+    Then some data should be generated
+    And foo contains anything but string data
+    And foo contains anything but numeric data

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/features/operators/grammatical/AllOf.feature
@@ -108,3 +108,17 @@ Feature: User can specify that data must be created to conform to each of multip
     Then the following data should be generated:
       | foo  |
       | null |
+
+  Scenario: User constrains type with not allOf construction should generate only datetimes
+    Given there is a field foo
+    And untyped fields are allowed
+    And there is a constraint:
+      """
+      { "allOf": [
+        { "not": { "field": "foo", "is": "ofType", "value": "string" }},
+        { "not": { "field": "foo", "is": "ofType", "value": "decimal" }}
+      ]}
+      """
+    Then some data should be generated
+    And foo contains anything but string data
+    And foo contains anything but numeric data

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
@@ -93,6 +93,11 @@ public class GeneralTestStep {
         this.state.addNotConstraint(fieldName, "null", null);
     }
 
+    @And("untyped fields are allowed")
+    public void fieldCanBeUntyped() {
+        this.state.setRequireFieldTyping(false);
+    }
+
     @Then("^the profile should be considered valid$")
     public void theProfileIsValid() {
         cucumberTestHelper.runChecksWithoutGeneratingData();

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberGenerationConfigSource.java
@@ -1,6 +1,7 @@
 package com.scottlogic.deg.orchestrator.cucumber.testframework.utils;
 
 import com.google.inject.Inject;
+import com.scottlogic.deg.common.profile.Profile;
 import com.scottlogic.deg.generator.config.detail.*;
 import com.scottlogic.deg.orchestrator.guice.AllConfigSource;
 import com.scottlogic.deg.orchestrator.violate.ViolateConfigSource;

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestHelper.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestHelper.java
@@ -8,12 +8,8 @@ import com.google.inject.util.Modules;
 import com.scottlogic.deg.common.ValidationException;
 import com.scottlogic.deg.common.profile.Field;
 import com.scottlogic.deg.orchestrator.generate.GenerateExecute;
-import com.scottlogic.deg.generator.guice.GeneratorModule;
-import com.scottlogic.deg.orchestrator.guice.AllModule;
 import com.scottlogic.deg.orchestrator.violate.ViolateExecute;
 import com.scottlogic.deg.orchestrator.violate.ViolateModule;
-import com.scottlogic.deg.profile.guice.ProfileModule;
-import com.scottlogic.deg.profile.reader.InvalidProfileException;
 import org.junit.Assert;
 
 import java.util.ArrayList;

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
@@ -5,6 +5,7 @@ import com.google.inject.name.Names;
 import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
 import com.scottlogic.deg.generator.generation.DataGenerator;
 import com.scottlogic.deg.generator.generation.GenerationConfigSource;
+import com.scottlogic.deg.generator.inputs.validation.MultipleProfileValidator;
 import com.scottlogic.deg.output.outputtarget.OutputTargetFactory;
 import com.scottlogic.deg.output.outputtarget.SingleDatasetOutputTarget;
 import com.scottlogic.deg.profile.reader.ProfileReader;
@@ -36,7 +37,11 @@ public class CucumberTestModule extends AbstractModule {
         bind(CucumberTestState.class).toInstance(testState);
         bind(ProfileReader.class).to(CucumberProfileReader.class);
         bind(GenerationConfigSource.class).to(CucumberGenerationConfigSource.class);
-        bind(ProfileValidator.class).to(TypingRequiredPerFieldValidator.class);
+        if (testState.requireFieldTyping) {
+            bind(ProfileValidator.class).to(TypingRequiredPerFieldValidator.class);
+        } else {
+            bind(ProfileValidator.class).to(MultipleProfileValidator.class);
+        }
         bind(ErrorReporter.class).toInstance(new CucumberErrorReporter(testState));
         bind(DecisionTreeFactory.class).to(CucumberDecisionTreeFactory.class);
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestModule.java
@@ -38,6 +38,8 @@ public class CucumberTestModule extends AbstractModule {
         bind(ProfileReader.class).to(CucumberProfileReader.class);
         bind(GenerationConfigSource.class).to(CucumberGenerationConfigSource.class);
         if (testState.requireFieldTyping) {
+            // This binding overrides the requireFieldTyping config option, so an alternative
+            // (MultipleProfileValidator) needs to be used when field typing is not required.
             bind(ProfileValidator.class).to(TypingRequiredPerFieldValidator.class);
         } else {
             bind(ProfileValidator.class).to(MultipleProfileValidator.class);

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/utils/CucumberTestState.java
@@ -27,6 +27,7 @@ public class CucumberTestState {
      * If true, generation is in violate mode.
      */
     public Boolean shouldViolate;
+    // Sets or unsets flag --allow-untyped-fields
     boolean requireFieldTyping;
 
     /** If true, we inject a no-op generation engine during the test (e.g. because we're just testing profile validation) */
@@ -167,6 +168,10 @@ public class CucumberTestState {
         }
 
         maxStringLength = maxLength;
+    }
+
+    public void setRequireFieldTyping(boolean requireFieldTyping) {
+        this.requireFieldTyping = requireFieldTyping;
     }
 }
 


### PR DESCRIPTION
### Description
- Removed "micro-optimisation" which was optimising incorrectly in some cases.

### Changes
- Removed broken code.
- Added unit tests.
- Added cucumber tests.
- Added cucumber construct "untyped fields are allowed" to emulate --allow-untyped-fields.

### Additional notes
- Adds a constructor for MultipleProfileValidator purely for testing, so there might be a better way to do this.
- Adds a conditional binding for test instances of ProfileValidator. There might be a better way to do this.

### Issue
Resolves #1006 
Resolves #981 
