### PR TITLE
Update step definitions to allow use of singular nouns

### DIFF
--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/cucumber/testframework/steps/GeneralTestStep.java
@@ -228,7 +228,7 @@ public class GeneralTestStep {
         Assert.assertThat("No data was generated but some was expected", data, not(empty()));
     }
 
-    @Then("{long} rows of data are generated")
+    @Then("{long} row(s) of data is/are generated")
     public void theExpectedNumberOfRowsAreGenerated(long expectedNumberOfRows) {
         List <List<Object>> data = cucumberTestHelper.generateAndGetData();
 
@@ -239,7 +239,7 @@ public class GeneralTestStep {
             equalTo(expectedNumberOfRows));
     }
 
-    @Given("the generator can generate at most {long} rows")
+    @Given("the generator can generate at most {long} row(s)")
     public void theGeneratorCanGenerateAtMostRows(long maxNumberOfRows) {
         state.maxRows = maxNumberOfRows;
     }


### PR DESCRIPTION
### Description
Just a minor change to allow use of singular grammar as well as plural for a couple of steps - so if you wanted a step to check a single row was generated you could now use step `Then 1 row of data is generated` instead of the previous `Then 1 rows of data are generated` or if you wanted to generate max 1 row you could write `Given the generator can generate at most 1 row` instead of  `Given the generator can generate at most 1 rows`. 