### PR TITLE
Added Dockerfile that builds DataHelix inside its own docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM openjdk:8u212-jdk-stretch AS build
+
+WORKDIR /root
+
+ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_VERSION 5.4.1
+
+RUN wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+RUN unzip gradle.zip
+RUN rm gradle.zip
+RUN mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/"
+RUN ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+
+COPY . /root/
+
+RUN gradle fatJar
+
+FROM openjdk:8u212-jre-alpine
+
+WORKDIR /root
+COPY --from=build /root/orchestrator/build/libs/generator.jar .
+
+ENTRYPOINT ["java", "-jar", "generator.jar"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker build . --tag "datahelix"


### PR DESCRIPTION
Added Dockerfile that builds DataHelix inside its own docker environment and generates a docker container that only contains the fatJar executable and the Java 8 JRE.

I did this to make sure I could build this without messing up my local machine but I thought it might be useful to include in the project.

### Description
This Dockerfile provides an executable definition of how to build DataHelix and produces a self-contained executable Docker image which might (in some cases) be an easier alternative for running DataHelix without having to install a JRE.

### Changes
It just adds the files `docker-build.sh` which is a shell script which builds the Dockerfile and `Dockerfile` the docker image definition to build.

### Additional notes
Once built you can run the image with:

```shell
docker run -ti -v mydir:/data datahelix [parameters]
```

Note that the `-v` option specifies how to map your local file system into the image so that DataHelix can access the files you pass to it.  For example, if you run the image in the project directory you can enter:

```shell
docker run -ti -v $PWD:/data datahelix generate --profile-file=/data/examples/actor-names/profile.json
```
This maps the maps your local project directories full pathname `$PWD` to the `/data` directory in the docker image so that the path `/data/examples/actor-names/profile.json` is accessing your local file as an input.


### Issue
Resolves #000
or
Related to #000
