### PR TITLE
Add basic Jar/E2E test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       # If changing build tools be sure to update GeneratorSetup.md in docs
-      - run: gradle :output:test :profile:test :generator:test :common:test :orchestrator:test
+      - run: gradle :fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       # If changing build tools be sure to update GeneratorSetup.md in docs
-      - run: gradle :other:fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
+      - run: gradle :datahelix:fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       # If changing build tools be sure to update GeneratorSetup.md in docs
-      - run: gradle :datahelix:fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
+      - run: gradle fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
       # If changing build tools be sure to update GeneratorSetup.md in docs
-      - run: gradle :fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
+      - run: gradle :other:fatJar :output:test :profile:test :generator:test :common:test :orchestrator:test
       - run:
           name: Save test results
           command: |

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -3,6 +3,7 @@ package com.scottlogic.deg.orchestrator.endtoend;
 import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,8 +22,7 @@ public class JarExecuteTests {
             p.waitFor();
             p.destroy();
 
-            assertEquals(2,collectedOutput.size());
-            assertEquals("\"Generation successful\"",collectedOutput.get(1));
+            assertEquals(Arrays.asList("foo", "\"Generation successful\""), collectedOutput);
     }
 }
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -13,16 +13,16 @@ public class JarExecuteTests {
             ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate", "-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json", "--max-rows=1");
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            List<String> STDOUT = new ArrayList<String>();
+            List<String> collectedOutput = new ArrayList<String>();
             String line;
             while ((line = BufferedSTDOUTReader.readLine()) != null) {
-                STDOUT.add(line);
+                collectedOutput.add(line);
             }
             p.waitFor();
             p.destroy();
 
-            assertEquals(2,STDOUT.size());
-            assertEquals("\"Generation successful\"",STDOUT.get(1));
+            assertEquals(2,collectedOutput.size());
+            assertEquals("\"Generation successful\"",collectedOutput.get(1));
     }
 }
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -18,12 +18,11 @@ public class JarExecuteTests {
             String line;
             while ((line = BufferedSTDOUTReader.readLine()) != null) {
                 STDOUT.add(line);
-                System.out.println(line);
             }
             p.waitFor();
             p.destroy();
 
-            assertEquals("\"Generation successful\"",STDOUT.get(1));
+            assertEquals("\"Generation successful\"",STDOUT.get(0));
     }
     }
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -10,7 +10,7 @@ public class JarExecuteTests {
 
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
-            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "\"build\\libs\\generator.jar\"", "generate","-p=\"src\\test\\java\\com\\scottlogic\\deg\\orchestrator\\endtoend\\testprofile.profile.json\"","--max-rows=1");
+            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "\"build/libs/generator.jar\"", "generate","-p=\"src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json\"","--max-rows=1");
             pb.redirectErrorStream(true);
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -1,0 +1,28 @@
+package com.scottlogic.deg.orchestrator.endtoend;
+
+import org.junit.jupiter.api.Test;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JarExecuteTests {
+
+    @Test
+    void GenerateSuccessfullyFromJar() throws Exception {
+            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "\"build\\libs\\generator.jar\"", "generate","-p=\"src\\test\\java\\com\\scottlogic\\deg\\orchestrator\\endtoend\\testprofile.profile.json\"","--max-rows=1");
+
+            Process p = pb.start();
+            BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            List<String> STDOUT = new ArrayList<String>();
+            String line;
+            while ((line = BufferedSTDOUTReader.readLine()) != null) {
+                STDOUT.add(line);
+            }
+            p.waitFor();
+            p.destroy();
+
+            assertEquals("\"Generation successful\"",STDOUT.get(1));
+    }
+    }
+

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -10,7 +10,7 @@ public class JarExecuteTests {
 
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
-            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "\"build/libs/generator.jar\"", "generate","-p=\"src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json\"","--max-rows=1");
+            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate","-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json","--max-rows=1");
             pb.redirectErrorStream(true);
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
@@ -22,7 +22,6 @@ public class JarExecuteTests {
             p.waitFor();
             p.destroy();
 
-            assertEquals("Tell me the working directory",System.getProperty("user.dir"));
             assertEquals("\"Generation successful\"",STDOUT.get(0));
     }
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -22,6 +22,7 @@ public class JarExecuteTests {
             p.waitFor();
             p.destroy();
 
+            assertEquals("Tell me the working directory",System.getProperty("user.dir"));
             assertEquals("\"Generation successful\"",STDOUT.get(0));
     }
     }

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -11,7 +11,6 @@ public class JarExecuteTests {
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
             ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate","-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json","--max-rows=1");
-            pb.redirectErrorStream(true);
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
             List<String> STDOUT = new ArrayList<String>();
@@ -22,7 +21,8 @@ public class JarExecuteTests {
             p.waitFor();
             p.destroy();
 
-            assertEquals("\"Generation successful\"",STDOUT.get(0));
+            assertEquals(2,STDOUT.size());
+            assertEquals("\"Generation successful\"",STDOUT.get(1));
     }
     }
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -11,13 +11,14 @@ public class JarExecuteTests {
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
             ProcessBuilder pb = new ProcessBuilder("java", "-jar", "\"build\\libs\\generator.jar\"", "generate","-p=\"src\\test\\java\\com\\scottlogic\\deg\\orchestrator\\endtoend\\testprofile.profile.json\"","--max-rows=1");
-
+            pb.redirectErrorStream(true);
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
             List<String> STDOUT = new ArrayList<String>();
             String line;
             while ((line = BufferedSTDOUTReader.readLine()) != null) {
                 STDOUT.add(line);
+                System.out.println(line);
             }
             p.waitFor();
             p.destroy();

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -11,7 +11,8 @@ public class JarExecuteTests {
 
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
-            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate", "-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json", "--max-rows=1");
+            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate", "-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json", "--max-rows=1", "--quiet");
+            pb.redirectErrorStream(true);
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
             List<String> collectedOutput = new ArrayList<String>();

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/JarExecuteTests.java
@@ -10,7 +10,7 @@ public class JarExecuteTests {
 
     @Test
     void GenerateSuccessfullyFromJar() throws Exception {
-            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate","-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json","--max-rows=1");
+            ProcessBuilder pb = new ProcessBuilder("java", "-jar", "build/libs/generator.jar", "generate", "-p=src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json", "--max-rows=1");
             Process p = pb.start();
             BufferedReader BufferedSTDOUTReader = new BufferedReader(new InputStreamReader(p.getInputStream()));
             List<String> STDOUT = new ArrayList<String>();
@@ -24,5 +24,5 @@ public class JarExecuteTests {
             assertEquals(2,STDOUT.size());
             assertEquals("\"Generation successful\"",STDOUT.get(1));
     }
-    }
+}
 

--- a/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json
+++ b/orchestrator/src/test/java/com/scottlogic/deg/orchestrator/endtoend/testprofile.profile.json
@@ -1,0 +1,36 @@
+{
+    "schemaVersion": "0.1",
+    "description": "Testing Profile",
+    "fields": [
+        {
+            "name": "foo"
+        }
+    ],
+    "rules": [
+        {
+            "rule": "rule1",
+            "constraints": [
+                {
+                    "field": "foo",
+                    "is": "equalTo",
+                    "value": "Generation successful"
+                }
+            ]
+        },
+        {
+            "rule": "rule2",
+            "constraints": [
+                {
+                        "field": "foo",
+                        "is": "ofType",
+                        "value": "string"
+                },
+                {"not": {
+                    "field": "foo",
+                    "is": "null"
+            }
+        }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Description
This test simply runs the generator from the jar and checks that a single line from a simple profile is generated correctly. Only tests STDOUT, not csv generation. 

After much messing around with the path it now works both locally and on CircleCI!

If there is a better way of doing this than ProcessBuilder then let me know. In future this could be expanded to test more things but the intention of this one test is mostly just to check jar generation isn't completely broken rather than to test generator features which is left to cucumber. The next step might be to check command line options are applied as this is currently not tested in cucumber.