### PR TITLE
Update documentation to include stdout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We'll start by generating data for a trivial schema. Using your favourite text e
 Now place the `generator.jar` file (downloaded from the [GitHub releases page](https://github.com/ScottLogic/datahelix/releases/)) in the same folder as the profile, open up a terminal, and execute the following:
 
 ~~~
-$ java -jar generator.jar generate --max-rows=100 --allow-untyped-fields --replace profile.json output.csv
+$ java -jar generator.jar generate --max-rows=100 --allow-untyped-fields --replace --profile-file=profile.json --output-path=output.csv
 Generation started at: 08:02:52
 
 Number of rows | Velocity (rows/sec) | Velocity trend
@@ -58,7 +58,7 @@ Number of rows | Velocity (rows/sec) | Velocity trend
 
 <!-- bug velocity not right -->
 
-The generator is a command line tool which reads a profile, and outputs data in CSV format. The `--max-rows=100` option tells the generator to create 100 rows of data, and the `--replace` option tells it to overwrite previously generated files. The generator outputs progress, in rows per second, which is useful when generating large volumes of data.
+The generator is a command line tool which reads a profile, and outputs data in CSV format. The `--max-rows=100` option tells the generator to create 100 rows of data, and the `--replace` option tells it to overwrite previously generated files.  The compulsary `--profile-file` option specifies the name of the input profile, and the `--output-path` option specifies the location to write the output to.  In `generate` mode `--output-path` is optional; the generator will default to standard output if it is not supplied.  By default the generator outputs progress, in rows per second, to the standard error output.  This can be useful when generating large volumes of data.
 
 If you open up `output.csv` you'll see the following:
 
@@ -139,7 +139,7 @@ The current profile outputs random text strings for the `firstName` field. Depen
 The generator has been designed to be fast and efficient, allowing you to generate large quantities of test and simulation data. If you supply a large number for the `--max-rows` option, the data will be streamed to the output file, with the progress / velocity reported during generation.
 
 ```
-$ java -jar generator.jar generate --max-rows=10000 --replace profile.json output.csv
+$ java -jar generator.jar generate --max-rows=10000 --replace --profile-file=profile.json --output-path=output.csv
 Generation started at: 16:41:44
 
 Number of rows | Velocity (rows/sec) | Velocity trend
@@ -303,7 +303,7 @@ The generator supports a number of different generation modes:
 The mode is specified via the `--generation-type` option. The following example outputs 'interesting' values for the current profile:
 
 ~~~
-$ java -jar generator.jar generate --generation-type interesting --replace profile.json output.csv
+$ java -jar generator.jar generate --generation-type interesting --replace --profile-file=profile.json --output-path=output.csv
 ~~~
 
 In this case it generates just 14 rows where you can see that it is exploring the boundary values of the constraints:
@@ -333,7 +333,7 @@ firstName,age,nationalInsurance
 One of the most powerful features of the generator is its ability to generate data that violates constraints. To create invalid data use the `violate` command. This time you need to specify an output directory rather than a file:
 
 ~~~
-$ java -jar generator.jar violate --max-rows=100 --replace profile.json out
+$ java -jar generator.jar violate --max-rows=100 --replace --profile-file=profile.json --output-path=out
 ~~~
 
 When the above command has finished, you'll find that the generator has created an `out` directory which has four files:
@@ -382,7 +382,7 @@ However, it might be a surprise to see nulls, numbers and dates as values for th
 
 ~~~
 $ java -jar generator.jar violate --dont-violate=ofType \
-  --max-rows=100 --replace profile.json out
+  --max-rows=100 --replace --profile-file=profile.json --output-path=out
 ~~~
 
 Or, alternatively, you can re-arrange your constraints so that the ones that define types / null, are grouped as a single rule. After By re-grouping constraints, the following output, with random strings that violate the regex constraint, is generated:

--- a/docs/FrequentlyAskedQuestions.md
+++ b/docs/FrequentlyAskedQuestions.md
@@ -68,20 +68,6 @@ All fields permit the inclusion of the empty set (&#8709;) by default, to preven
 
 For more details see the [set restriction and generation](./../generator/docs/SetRestrictionAndGeneration.md) page.
 
-## Why can I not combine regex constraints with some `ofType` constraints
-
-If a profile contains both `ofType` constraint(s) that refer to financial codes, and `matchingRegex` or `containingRegex` constraint(s) that apply to the same field(s), no data will be emitted, even if the regexes could potentially match valid values produced by the `ofType` constraints.
-
-This is a limitation with the current implementation of the generator, there are plans to solve this issue - see [#487](https://github.com/ScottLogic/datahelix/issues/487) for progress. 
-
-Combining an `ofType` constraint with any other constraints is still permitted and will produce data where appropriate.  Combining other kinds of `ofType` constraint with `matchingRegex` or `containingRegex` constraints is also permitted.
-
-Valid examples are:
-* `ofType ISIN` & `inSet [ "GB0002634947", 123 ]` - will emit `null` and `"GB0002634947"`
-* `not(ofType CUSIP)` & `inSet [ "594918104", 123 ]` - will emit `null` and `123`
-* `ofType ISIN` & `equalTo "GB0002634947"` - will emit `null` and `"GB0002634947"`
-* `ofType SEDOL` & `greaterThan 5` - will emit `null` and all valid SEDOL codes
-
 ## Why are we continuing to use an out-of-date JDK
 
 Currently we're using version 1.8 of the Java development toolkit (JDK), there are newer versions which fix some issues found in 1.8.

--- a/docs/GettingStarted/GeneratingData.md
+++ b/docs/GettingStarted/GeneratingData.md
@@ -9,22 +9,22 @@ For first time setup, see the [Generator setup instructions](../generator/docs/G
 
 To generate data run the following command from the command line
 
-`java -jar <path to JAR file> generate [options] "<path to profile>" "<desired output path>"`
+`java -jar <path to JAR file> generate [options] --profile-file="<path to profile>" --output-path="<desired output path>"`
 
 * `[path to JAR file]` the location of generator.jar
 * `[options]` optionally a combination of [options](../Options/GenerateOptions.md) to configure how the command operates
 * `<path to profile>` the location of the JSON profile file
-* `<desired output path>` the location of the generated data
+* `<desired output path>` the location of the generated data.  If this option is omitted, generated data will be streamed to the standard output.
 
 ## Example - Generating Valid Data
 
 Using the [Sample Profile](./ExampleProfile1.json) that was created in the [previous](./CreatingAProfile.md) section, run the following command:
 
- `java -jar <path to JAR file> generate "<path to ExampleProfile1.json>" "<path to desired output file>"`
+ `java -jar <path to JAR file> generate --profile-file="<path to ExampleProfile1.json>" --output-path="<path to desired output file>"`
 
 * `<path to desired output file>` the file path to the desired output file 
 
-With no options this should yield the following data:
+With no other options this should yield the following data:
 
 |Column 1       |Column 2     |
 |:-------------:|:-----------:|
@@ -43,7 +43,7 @@ Using the `violate` command produces one file per rule violated along with a man
 
 Using the [Sample Profile](./ExampleProfile1.json) that was created in the [first](./CreatingAProfile.md) section, run the following command: 
 
-`java -jar <path to JAR file> violate "<path to ExampleProfile1.json>" "<path to desired output directory>"`
+`java -jar <path to JAR file> violate --profile-file="<path to ExampleProfile1.json>" --output-path="<path to desired output directory>"`
 
 * `<path to desired output directory>` the location of the folder in which the generated files will be saved
 

--- a/docs/GettingStarted/Visualise.md
+++ b/docs/GettingStarted/Visualise.md
@@ -10,12 +10,12 @@ for manual inspection, in the form of a gv file.
 
 To visualise the decision tree run the following command from the command line:
 
-`java -jar <path to JAR file> visualise [options] "<path to profile>" "<path to desired output GV file>"`
+`java -jar <path to JAR file> visualise [options] --profile-file="<path to profile>" --output-path="<path to desired output GV file>"`
 
 * `[path to JAR file]` the location of generator.jar
 * `[options]` optionally a combination of [options](../Options/VisualiseOptions.md) to configure how the command operates
 * `<path to profile>` the location of the JSON profile file
-* `<path to desired output directory>` the location of the folder for the resultant GV file of the tree
+* `<path to desired output GV file>` the location of the folder for the resultant GV file of the tree
 
 ## Example
 

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -1,6 +1,10 @@
 # Generate Options
 Option switches are case-sensitive, arguments are case-insensitive
 
+* `--profile-file=<path>`
+    * Path to the input profile file.
+* `--output-path=<path>`
+    * Path to the output file.  If not specified, output will be to standard output.
 * `--replace`
     * Overwrite/replace existing output files.
 * `-n <rows>` or `--max-rows <rows>`

--- a/docs/Options/GenerateOptions.md
+++ b/docs/Options/GenerateOptions.md
@@ -1,9 +1,9 @@
 # Generate Options
 Option switches are case-sensitive, arguments are case-insensitive
 
-* `--profile-file=<path>`
+* `--profile-file=<path>` (or `-p <path>`)
     * Path to the input profile file.
-* `--output-path=<path>`
+* `--output-path=<path>` (or `-o <path>`)
     * Path to the output file.  If not specified, output will be to standard output.
 * `--replace`
     * Overwrite/replace existing output files.

--- a/docs/Options/ViolateOptions.md
+++ b/docs/Options/ViolateOptions.md
@@ -1,9 +1,9 @@
 # Violate Options
 Option switches are case-sensitive, arguments are case-insensitive
 
-* `--profile-file=<path>`
+* `--profile-file=<path>` (or `-p <path>`)
    * Path to input profile file.
-* `--output-path=<path>`
+* `--output-path=<path>` (or `-o <path>`)
    * Path to output directory.
 * `--replace`
     * Overwrite/replace existing output files.

--- a/docs/Options/ViolateOptions.md
+++ b/docs/Options/ViolateOptions.md
@@ -1,6 +1,10 @@
 # Violate Options
 Option switches are case-sensitive, arguments are case-insensitive
 
+* `--profile-file=<path>`
+   * Path to input profile file.
+* `--output-path=<path>`
+   * Path to output directory.
 * `--replace`
     * Overwrite/replace existing output files.
 * `--dont-violate` <epistemic constraints...>

--- a/docs/Options/VisualiseOptions.md
+++ b/docs/Options/VisualiseOptions.md
@@ -1,9 +1,9 @@
 # Visualise Options
 Option switches are case-sensitive, arguments are case-insensitive
 
-* `--profile-file=<path>`
+* `--profile-file=<path>` (or `-p <path>`)
    * Path to input profile file.
-* `--output-path=<path>`
+* `--output-path=<path>` (or `-o <path>`)
    * Path to visualisation output file.
 * `-t <title>` or `--title <title>`
    * Include the given `<title>` in the visualisation. If not supplied, the description of in profile will be used, or the filename of the profile.

--- a/docs/Options/VisualiseOptions.md
+++ b/docs/Options/VisualiseOptions.md
@@ -1,6 +1,10 @@
 # Visualise Options
 Option switches are case-sensitive, arguments are case-insensitive
 
+* `--profile-file=<path>`
+   * Path to input profile file.
+* `--output-path=<path>`
+   * Path to visualisation output file.
 * `-t <title>` or `--title <title>`
    * Include the given `<title>` in the visualisation. If not supplied, the description of in profile will be used, or the filename of the profile.
 * `--no-title`

--- a/docs/ProfileDeveloperGuide.md
+++ b/docs/ProfileDeveloperGuide.md
@@ -164,8 +164,6 @@ When this is specified as the type of a field, the data generated will contain l
 
 Data Helix currently only supports ISIN codes in the `GB` and `US` ranges.  Only codes in these ranges will be generated.
 
-There are currently limitations on using financial code types with regular expression constraints.  See [Frequently Asked Questions](FrequentlyAskedQuestions.md) for details.
-
 ## Personal Data Types
 
 Data Helix can generate data containing typical real names, based on recent demographic data, by defining a field as being of the types `firstname`, `lastname` or `fullname`.  Name fields are strings and can be combined with other textual constraints to generate, for example, first names that are longer than 6 letters.

--- a/generator/docs/GeneratorSetup.md
+++ b/generator/docs/GeneratorSetup.md
@@ -88,7 +88,7 @@ Build the tool with all its dependencies:
 
 To generate valid data run the following command from the command line:
 
-`java -jar <path to JAR file> generate [options] "<path to profile>" "<desired output path>"`
+`java -jar <path to JAR file> generate [options] --profile-file="<path to profile>" --output-path="<desired output path>"`
 
 * `[path to JAR file]` - the location of `generator.jar`.
 * `[options]` - optionally a combination of [options](../../docs/Options/GenerateOptions.md) to configure how the command operates.
@@ -97,7 +97,7 @@ To generate valid data run the following command from the command line:
 
 To generate violating data run the following command from the command line:
 
-`java -jar <path to JAR file> violate [options] "<path to profile>" "<desired output folder>"`
+`java -jar <path to JAR file> violate [options] --profile-file="<path to profile>" --output-path="<desired output folder>"`
 
 * `[path to JAR file]` - the location of `generator.jar`.
 * `[options]` - a combination of any (or none) of [the options documented here](../../docs/Options/ViolateOptions.md) to configure how the command operates.


### PR DESCRIPTION
### Description
Since merging the stdout feature, the Markdown documents have largely had incorrect syntax on their command-line examples

### Changes
* Update example command lines
* Include documentation of the `--profile-file` and `--output-path` options.

