### PR TITLE
Add dependency to test task in build.gradle

### DIFF
--- a/orchestrator/build.gradle
+++ b/orchestrator/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    dependsOn("fatJar")
 }
 
 description = 'DataHelix Generator'


### PR DESCRIPTION
### Description
Gradle task `orchestrator:test` is now dependent on fatJar and so will build the jar file if necessary. This prevents JarExecuteTests from failing if the jar has not previously been built.