### PR TITLE
896 upfront contradictory pruning minimal - fails silently

### DIFF
--- a/common/src/main/java/com/scottlogic/deg/common/profile/ProfileFields.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/ProfileFields.java
@@ -50,4 +50,8 @@ public class ProfileFields implements Iterable<Field> {
     public int hashCode() {
         return fields.hashCode();
     }
+
+    public List<Field> getFields() {
+        return this.fields;
+    }
 }

--- a/common/src/main/java/com/scottlogic/deg/common/profile/ProfileFields.java
+++ b/common/src/main/java/com/scottlogic/deg/common/profile/ProfileFields.java
@@ -50,8 +50,4 @@ public class ProfileFields implements Iterable<Field> {
     public int hashCode() {
         return fields.hashCode();
     }
-
-    public List<Field> getFields() {
-        return this.fields;
-    }
 }

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
@@ -1,0 +1,33 @@
+package com.scottlogic.deg.generator.generation;
+
+import com.google.inject.Inject;
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
+import com.scottlogic.deg.generator.decisiontree.DecisionTree;
+import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
+import com.scottlogic.deg.generator.walker.reductive.Merged;
+import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UpfrontTreePruner {
+    private ReductiveTreePruner treePruner;
+    @Inject
+    public UpfrontTreePruner(ReductiveTreePruner treePruner) {
+        this.treePruner = treePruner;
+    }
+
+    public DecisionTree runUpfrontPrune(DecisionTree tree) {
+        Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
+
+        for (Field field : tree.getFields().getFields()) {
+            fieldSpecs.put(field, FieldSpec.Empty);
+        }
+        Merged<ConstraintNode> prunedNode = treePruner.pruneConstraintNode(tree.getRootNode(), fieldSpecs);
+        if (prunedNode.isContradictory()) {
+            return new DecisionTree(null, tree.getFields(), tree.getDescription());
+        }
+        return new DecisionTree(prunedNode.get(), tree.getFields(), tree.getDescription());
+    }
+}

--- a/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/generation/UpfrontTreePruner.java
@@ -10,6 +10,8 @@ import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class UpfrontTreePruner {
     private ReductiveTreePruner treePruner;
@@ -19,11 +21,12 @@ public class UpfrontTreePruner {
     }
 
     public DecisionTree runUpfrontPrune(DecisionTree tree) {
-        Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
+        Map<Field, FieldSpec> fieldSpecs = tree.getFields().stream()
+            .collect(
+                Collectors.toMap(
+                    Function.identity(),
+                    f -> FieldSpec.Empty));
 
-        for (Field field : tree.getFields().getFields()) {
-            fieldSpecs.put(field, FieldSpec.Empty);
-        }
         Merged<ConstraintNode> prunedNode = treePruner.pruneConstraintNode(tree.getRootNode(), fieldSpecs);
         if (prunedNode.isContradictory()) {
             return new DecisionTree(null, tree.getFields(), tree.getDescription());

--- a/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveTreePruner.java
+++ b/generator/src/main/java/com/scottlogic/deg/generator/walker/reductive/ReductiveTreePruner.java
@@ -37,7 +37,7 @@ public class ReductiveTreePruner {
         return pruneConstraintNode(constraintNode, fieldToSpec);
     }
 
-    private Merged<ConstraintNode> pruneConstraintNode(ConstraintNode constraintNode, Map<Field, FieldSpec> fieldSpecs) {
+    public Merged<ConstraintNode> pruneConstraintNode(ConstraintNode constraintNode, Map<Field, FieldSpec> fieldSpecs) {
         Merged<Map<Field, FieldSpec>> newFieldSpecs = combineConstraintsWithParent(constraintNode, fieldSpecs);
         if (newFieldSpecs.isContradictory()){
             return Merged.contradictory();

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/DecisionTreeDataGeneratorTests.java
@@ -1,0 +1,102 @@
+package com.scottlogic.deg.generator.generation;
+
+import com.scottlogic.deg.common.output.GeneratedObject;
+import com.scottlogic.deg.common.profile.Profile;
+import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
+import com.scottlogic.deg.generator.decisiontree.DecisionTree;
+import com.scottlogic.deg.generator.decisiontree.DecisionTreeFactory;
+import com.scottlogic.deg.generator.decisiontree.DecisionTreeOptimiser;
+import com.scottlogic.deg.generator.decisiontree.treepartitioning.TreePartitioner;
+import com.scottlogic.deg.generator.generation.combinationstrategies.CombinationStrategy;
+import com.scottlogic.deg.generator.generation.databags.DataBag;
+import com.scottlogic.deg.generator.walker.DecisionTreeWalker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Matchers.any;
+
+public class DecisionTreeDataGeneratorTests {
+    private DecisionTreeDataGenerator generator;
+    private DecisionTreeFactory factory;
+    private DataGeneratorMonitor monitor;
+    private TreePartitioner treePartitioner;
+    private CombinationStrategy combinationStrategy;
+    private DecisionTreeOptimiser optimiser;
+    private DecisionTreeWalker treeWalker;
+    private UpfrontTreePruner upfrontTreePruner;
+    @BeforeEach
+    public void setup() {
+        factory = Mockito.mock(DecisionTreeFactory.class);
+        treeWalker = Mockito.mock(DecisionTreeWalker.class);
+        treePartitioner = Mockito.mock(TreePartitioner.class);
+        optimiser = Mockito.mock(DecisionTreeOptimiser.class);
+        monitor = Mockito.mock(DataGeneratorMonitor.class);
+        combinationStrategy = Mockito.mock(CombinationStrategy.class);
+        upfrontTreePruner = Mockito.mock(UpfrontTreePruner.class);
+        long maxRows = 10;
+        generator = new DecisionTreeDataGenerator(
+            factory,
+            treeWalker,
+            treePartitioner,
+            optimiser,
+            monitor,
+            combinationStrategy,
+            upfrontTreePruner,
+            maxRows
+        );
+    }
+
+    @Nested
+    public class upfrontContradictionChecking {
+        private DecisionTree tree;
+        private ConstraintNode rootNode;
+        private Profile profile;
+        @BeforeEach
+        public void setup() {
+            tree = Mockito.mock(DecisionTree.class);
+            rootNode = Mockito.mock(ConstraintNode.class);
+            profile = Mockito.mock(Profile.class);
+            DataBag value = Mockito.mock(DataBag.class);
+
+            Mockito.when(tree.getRootNode()).thenReturn(rootNode);
+            Mockito.when(factory.analyse(profile)).thenReturn(tree);
+            Mockito.when(combinationStrategy.permute(any())).thenReturn(Stream.of(value));
+            Mockito.when(treePartitioner.splitTreeIntoPartitions(any())).thenReturn(Stream.of(tree));
+            Mockito.when(optimiser.optimiseTree(any())).thenReturn(tree);
+        }
+
+        @Test
+        public void generateData_withWhollyContradictingProfile_returnsEmptyStream() {
+            //Arrange
+            DecisionTree outputTree = Mockito.mock(DecisionTree.class);
+            Mockito.when(outputTree.getRootNode()).thenReturn(null);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree)).thenReturn(outputTree);
+
+            //Act
+            Stream<GeneratedObject> actual = generator.generateData(profile);
+
+            //Assert
+            assertEquals(0, actual.count());
+        }
+
+        @Test
+        public void generateData_withNotWhollyContradictoryProfile_canReturnData() {
+            //Arrange
+            DecisionTree outputTree = Mockito.mock(DecisionTree.class);
+            Mockito.when(outputTree.getRootNode()).thenReturn(rootNode);
+            Mockito.when(upfrontTreePruner.runUpfrontPrune(tree)).thenReturn(outputTree);
+
+            //Act
+            Stream<GeneratedObject> actual = generator.generateData(profile);
+
+            //Assert
+            assertNotEquals(0, actual.count());
+        }
+    }
+}

--- a/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
+++ b/generator/src/test/java/com/scottlogic/deg/generator/generation/UpfrontTreePrunerTests.java
@@ -1,0 +1,52 @@
+package com.scottlogic.deg.generator.generation;
+
+import com.scottlogic.deg.common.profile.Field;
+import com.scottlogic.deg.common.profile.ProfileFields;
+import com.scottlogic.deg.generator.decisiontree.ConstraintNode;
+import com.scottlogic.deg.generator.decisiontree.DecisionTree;
+import com.scottlogic.deg.generator.fieldspecs.FieldSpec;
+import com.scottlogic.deg.generator.walker.reductive.Merged;
+import com.scottlogic.deg.generator.walker.reductive.ReductiveTreePruner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
+class UpfrontTreePrunerTests {
+    private UpfrontTreePruner upfrontTreePruner;
+    private ReductiveTreePruner reductiveTreePruner;
+    @BeforeEach
+    void setup() {
+        reductiveTreePruner = Mockito.mock(ReductiveTreePruner.class);
+        upfrontTreePruner = new UpfrontTreePruner(reductiveTreePruner);
+    }
+
+    @Test
+    void runUpfrontPrune_returnsPrunedTree() {
+        //Arrange
+        DecisionTree unprunedTree = Mockito.mock(DecisionTree.class);
+        Field field = new Field("A");
+        List<Field> fields = Collections.singletonList(field);
+        ProfileFields profileFields = Mockito.mock(ProfileFields.class);
+        Mockito.when(profileFields.getFields()).thenReturn(fields);
+        Mockito.when(unprunedTree.getFields()).thenReturn(profileFields);
+        ConstraintNode prunedRoot = Mockito.mock(ConstraintNode.class);
+        Map<Field, FieldSpec> fieldSpecs = new HashMap<>();
+        fieldSpecs.put(field, FieldSpec.Empty);
+        Mockito.when(reductiveTreePruner.pruneConstraintNode(any(), eq(fieldSpecs))).thenReturn(Merged.of(prunedRoot));
+
+        //Act
+        DecisionTree actual = upfrontTreePruner.runUpfrontPrune(unprunedTree);
+
+        //Assert
+        assertEquals(prunedRoot, actual.getRootNode());
+    }
+}


### PR DESCRIPTION
### Changes
- Pruner called on full tree at start of generation.
- Generation will terminate early if the profile is wholly contradictory and will not try to optimise.
- Unit tests added.

### Additional notes
- Does a small subset of https://github.com/ScottLogic/datahelix/pull/1040.
- Does not report contradictions to the user, but fails silently, generating no data.

### Issue
Resolves #1062 
Resolves #988 
Related #896
